### PR TITLE
CI Presubmit Check Patch

### DIFF
--- a/libavfilter/Makefile
+++ b/libavfilter/Makefile
@@ -349,6 +349,7 @@ OBJS-$(CONFIG_SETRANGE_FILTER)               += vf_setparams.o
 OBJS-$(CONFIG_SETSAR_FILTER)                 += vf_aspect.o
 OBJS-$(CONFIG_SETTB_FILTER)                  += settb.o
 OBJS-$(CONFIG_SHARPNESS_VAAPI_FILTER)        += vf_misc_vaapi.o vaapi_vpp.o
+OBJS-$(CONFIG_ROTATION_VAAPI_FILTER)         += vf_misc_vaapi.o vaapi_vpp.o
 OBJS-$(CONFIG_SHOWINFO_FILTER)               += vf_showinfo.o
 OBJS-$(CONFIG_SHOWPALETTE_FILTER)            += vf_showpalette.o
 OBJS-$(CONFIG_SHUFFLEFRAMES_FILTER)          += vf_shuffleframes.o

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -333,6 +333,7 @@ extern AVFilter ff_vf_setrange;
 extern AVFilter ff_vf_setsar;
 extern AVFilter ff_vf_settb;
 extern AVFilter ff_vf_sharpness_vaapi;
+extern AVFilter ff_vf_rotation_vaapi;
 extern AVFilter ff_vf_showinfo;
 extern AVFilter ff_vf_showpalette;
 extern AVFilter ff_vf_shuffleframes;

--- a/libavfilter/vaapi_vpp.h
+++ b/libavfilter/vaapi_vpp.h
@@ -44,6 +44,7 @@ typedef struct VAAPIVPPContext {
     int output_width;   // computed width
     int output_height;  // computed height
 
+    int rotation_state;
     VABufferID         filter_buffers[VAProcFilterCount];
     int                nb_filter_buffers;
 


### PR DESCRIPTION
Do a CI presubmit compile check for patch:

```
Author: Zachary Zhou <zachary.zhou@intel.com>
Date:   Tue Oct 23 15:52:40 2018 +0800

    libavfilter/vaapi: enable vaapi rotation feature via call Intel iHD driver
    
    It supports clockwise rotation by 0/90/180/270 degrees defined in
    va/va_vpp.h, tested following command line on SKL platform
    
    ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128
    -hwaccel_output_format vaapi -i input.264 -vf "rotation_vaapi=angle=90"
    -c:v h264_vaapi output.h264

```
