### PR TITLE
lavc/vaapi_encode_mpeg2: fix the desired packed header

### DIFF
--- a/libavcodec/vaapi_encode_mpeg2.c
+++ b/libavcodec/vaapi_encode_mpeg2.c
@@ -613,8 +613,7 @@ static av_cold int vaapi_encode_mpeg2_init(AVCodecContext *avctx)
         return AVERROR(EINVAL);
     }
 
-    ctx->desired_packed_headers = VA_ENC_PACKED_HEADER_SEQUENCE |
-                                  VA_ENC_PACKED_HEADER_PICTURE;
+    ctx->desired_packed_headers = VA_ENC_PACKED_HEADER_RAW_DATA;
 
     ctx->surface_width  = FFALIGN(avctx->width,  16);
     ctx->surface_height = FFALIGN(avctx->height, 16);


### PR DESCRIPTION
Only VA_ENC_PACKED_HEADER_RAW_DATA is supported as the packed header
for Mpeg2 profile in driver:

    else if (IsMpeg2Profile(profile))
    {
        attrib.value = VA_ENC_PACKED_HEADER_RAW_DATA;
    }

Modify to set the supported packed header and avoid the warning.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>