### PR TITLE
avfilter: clean vaapi vpp code

### DIFF
--- a/libavfilter/vf_deinterlace_vaapi.c
+++ b/libavfilter/vf_deinterlace_vaapi.c
@@ -255,12 +255,8 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
         params.surface_color_standard =
             ff_vaapi_vpp_colour_standard(input_frame->colorspace);
 
-        params.output_region = NULL;
         params.output_background_color = VAAPI_VPP_BACKGROUND_BLACK;
         params.output_color_standard = params.surface_color_standard;
-
-        params.pipeline_flags = 0;
-        params.filter_flags   = VA_FRAME_PICTURE;
 
         if (!ctx->auto_enable || input_frame->interlaced_frame) {
             vas = vaMapBuffer(vpp_ctx->hwctx->display, vpp_ctx->filter_buffers[0],

--- a/libavfilter/vf_misc_vaapi.c
+++ b/libavfilter/vf_misc_vaapi.c
@@ -164,10 +164,9 @@ static int misc_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
         .height = input_frame->height,
     };
 
-    if (vpp_ctx->nb_filter_buffers) {
-        params.filters     = &vpp_ctx->filter_buffers[0];
-        params.num_filters = vpp_ctx->nb_filter_buffers;
-    }
+    params.filters     = &vpp_ctx->filter_buffers[0];
+    params.num_filters = vpp_ctx->nb_filter_buffers;
+
     params.surface = input_surface;
     params.surface_region = &input_region;
     params.surface_color_standard =
@@ -176,9 +175,6 @@ static int misc_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
     params.output_region = NULL;
     params.output_background_color = VAAPI_VPP_BACKGROUND_BLACK;
     params.output_color_standard = params.surface_color_standard;
-
-    params.pipeline_flags = 0;
-    params.filter_flags = VA_FRAME_PICTURE;
 
     err = ff_vaapi_vpp_render_picture(avctx, &params, output_surface);
     if (err < 0)

--- a/libavfilter/vf_procamp_vaapi.c
+++ b/libavfilter/vf_procamp_vaapi.c
@@ -174,11 +174,8 @@ static int procamp_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame
     params.output_background_color = VAAPI_VPP_BACKGROUND_BLACK;
     params.output_color_standard = params.surface_color_standard;
 
-    params.pipeline_flags = 0;
-    params.filter_flags = VA_FRAME_PICTURE;
-
     params.filters     = &vpp_ctx->filter_buffers[0];
-    params.num_filters = 1;
+    params.num_filters = vpp_ctx->nb_filter_buffers;
 
     err = ff_vaapi_vpp_render_picture(avctx, &params, output_surface);
     if (err < 0)

--- a/libavfilter/vf_scale_vaapi.c
+++ b/libavfilter/vf_scale_vaapi.c
@@ -132,11 +132,9 @@ static int scale_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
     params.surface_color_standard =
         ff_vaapi_vpp_colour_standard(input_frame->colorspace);
 
-    params.output_region = 0;
     params.output_background_color = VAAPI_VPP_BACKGROUND_BLACK;
     params.output_color_standard = params.surface_color_standard;
 
-    params.pipeline_flags = 0;
     params.filter_flags = ctx->mode;
 
     err = ff_vaapi_vpp_render_picture(avctx, &params, output_surface);


### PR DESCRIPTION
params.pipeline_flags:
https://github.com/intel/libva/blob/master/va/va_vpp.h#L503-L529

params.filter_flags:
https://github.com/intel/libva/blob/master/va/va.h#L217-L220

Signed-off-by: Zachary Zhou <zachary.zhou@intel.com>