### PR TITLE
lavc/qsvdec: resolution check for reinit without alignment

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -524,8 +524,7 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
     avctx->field_order  = q->parser->field_order;
     /* TODO: flush delayed frames on reinit */
     if (q->parser->format       != q->orig_pix_fmt    ||
-        FFALIGN(q->parser->coded_width, 16)  != FFALIGN(avctx->coded_width, 16) ||
-        FFALIGN(q->parser->coded_height, 16) != FFALIGN(avctx->coded_height, 16)) {
+        q->height != q->parser->coded_height || q->width !=  q->parser->coded_width) {
         enum AVPixelFormat pix_fmts[3] = { AV_PIX_FMT_QSV,
                                            AV_PIX_FMT_NONE,
                                            AV_PIX_FMT_NONE };
@@ -558,6 +557,8 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
         avctx->coded_height = FFALIGN(q->parser->coded_height, 16);
         avctx->level        = q->avctx_internal->level;
         avctx->profile      = q->avctx_internal->profile;
+        q->width            = q->parser->coded_width;
+        q->height           = q->parser->coded_height;
 
         ret = ff_get_format(avctx, pix_fmts);
         if (ret < 0)

--- a/libavcodec/qsvdec.h
+++ b/libavcodec/qsvdec.h
@@ -55,6 +55,8 @@ typedef struct QSVContext {
     int zero_consume_run;
     int buffered_count;
     int reinit_flag;
+    int width;
+    int height;
 
     // the internal parser and codec context for parsing the data
     AVCodecParserContext *parser;


### PR DESCRIPTION
resolution check for reinit without alignment based on 16.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>