### PR TITLE
[ICL+]lavc/vaapi_decode: Add vaapi 422 YUY2 Decode support for HEVC

### DIFF
--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -409,6 +409,15 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
 #endif
         break;
     case AV_PIX_FMT_YUV420P12:
+#if CONFIG_HEVC_NVDEC_HWACCEL
+        *fmt++ = AV_PIX_FMT_CUDA;
+#endif
+        break;
+    case AV_PIX_FMT_YUV422P:
+#if CONFIG_HEVC_VAAPI_HWACCEL
+	*fmt++ = AV_PIX_FMT_VAAPI;
+#endif
+	break;
     case AV_PIX_FMT_YUV444P:
     case AV_PIX_FMT_YUV444P10:
     case AV_PIX_FMT_YUV444P12:

--- a/libavcodec/vaapi_decode.c
+++ b/libavcodec/vaapi_decode.c
@@ -256,6 +256,9 @@ static const struct {
 #ifdef VA_FOURCC_YV16
     MAP(YV16, YUV422P),
 #endif
+#ifdef VA_FOURCC_YUY2
+    MAP(YUY2, YUYV422),
+#endif
     // 4:4:0
     MAP(422V, YUV440P),
     // 4:4:4


### PR DESCRIPTION
Signed-off-by: Linjie Fu <linjie.fu@intel.com>