### PR TITLE
add vdsfc to h264 decoder

### DIFF
--- a/fftools/ffmpeg_opt.c
+++ b/fftools/ffmpeg_opt.c
@@ -111,6 +111,10 @@ int filter_nbthreads = 0;
 int filter_complex_nbthreads = 0;
 int vstats_version = 2;
 
+int sfc_flags = 0;
+int sfc_width = 0;
+int sfc_height = 0;
+char *sfc_format;
 
 static int intra_only         = 0;
 static int file_overwrite     = 0;
@@ -1100,6 +1104,13 @@ static int open_input_file(OptionsContext *o, const char *filename)
         av_dict_set(&o->g->format_opts, "scan_all_pmts", "1", AV_DICT_DONT_OVERWRITE);
         scan_all_pmts_set = 1;
     }
+
+    //sfc opt
+    av_dict_set_int(&o->g->codec_opts, "sfc_flags", sfc_flags, AV_DICT_DONT_OVERWRITE);
+    av_dict_set_int(&o->g->codec_opts, "sfc_width", sfc_width, AV_DICT_DONT_OVERWRITE);
+    av_dict_set_int(&o->g->codec_opts, "sfc_height", sfc_height, AV_DICT_DONT_OVERWRITE);
+    av_dict_set(&o->g->codec_opts, "sfc_format", sfc_format, AV_DICT_DONT_OVERWRITE);
+
     /* open the input file with generic avformat function */
     err = avformat_open_input(&ic, filename, file_iformat, &o->g->format_opts);
     if (err < 0) {
@@ -2898,6 +2909,13 @@ static int opt_vstats_file(void *optctx, const char *opt, const char *arg)
     return 0;
 }
 
+static int opt_sfc_format(void *optctx, const char *opt, const char *arg)
+{
+    av_free (sfc_format);
+    sfc_format = av_strdup (arg);
+    return 0;
+}
+
 static int opt_vstats(void *optctx, const char *opt, const char *arg)
 {
     char filename[40];
@@ -3745,6 +3763,16 @@ const OptionDef options[] = {
         "initialise hardware device", "args" },
     { "filter_hw_device", HAS_ARG | OPT_EXPERT, { .func_arg = opt_filter_hw_device },
         "set hardware device used when filtering", "device" },
+
+    //sfc opt
+    { "sfc_flags",    OPT_VIDEO | HAS_ARG | OPT_INT | OPT_INPUT, { &sfc_flags },
+      "set sfc flags", "sfc" },
+    { "sfc_width",    OPT_VIDEO | HAS_ARG | OPT_INT | OPT_INPUT, { &sfc_width },
+      "set sfc width", "sfc" },
+    { "sfc_height",   OPT_VIDEO | HAS_ARG | OPT_INT | OPT_INPUT, { &sfc_height },
+      "set sfc height", "sfc" },
+    { "sfc_format",  OPT_VIDEO | HAS_ARG | OPT_EXPERT ,  { .func_arg = opt_sfc_format },
+        "set sfc format", "sfc" },
 
     { NULL, },
 };

--- a/libavcodec/avcodec.h
+++ b/libavcodec/avcodec.h
@@ -3357,6 +3357,14 @@ typedef struct AVCodecContext {
      * - encoding: unused
      */
     int discard_damaged_percentage;
+
+    /*
+     * VDSFC options
+     */
+    int sfc_flags;
+    int sfc_format;
+    int sfc_width;
+    int sfc_height;
 } AVCodecContext;
 
 #if FF_API_CODEC_GET_SET

--- a/libavcodec/decode.c
+++ b/libavcodec/decode.c
@@ -1795,6 +1795,22 @@ FF_ENABLE_DEPRECATION_WARNINGS
         frame->channels = avctx->channels;
         break;
     }
+
+    //sfc side data
+    if (avctx->sfc_flags) {
+        AVFrameSideData *frame_sfc_sd = av_frame_new_side_data(frame,
+                                                               AV_FRAME_DATA_SFC_INFO,
+                                                               sizeof(AVSFCInfo));
+        if (frame_sfc_sd) {
+            av_dict_set_int(&frame_sfc_sd->metadata, "sfc_flags", avctx->sfc_flags, 0);
+            av_dict_set_int(&frame_sfc_sd->metadata, "sfc_width", avctx->sfc_width, 0);
+            av_dict_set_int(&frame_sfc_sd->metadata, "sfc_height", avctx->sfc_height, 0);
+            av_dict_set_int(&frame_sfc_sd->metadata, "sfc_format", avctx->sfc_format, 0);
+
+            av_log(avctx, AV_LOG_DEBUG, "VDSFC new side data\n");
+        }
+    }
+
     return 0;
 }
 

--- a/libavcodec/options_table.h
+++ b/libavcodec/options_table.h
@@ -480,6 +480,10 @@ static const AVOption avcodec_options[] = {
 {"allow_profile_mismatch", "attempt to decode anyway if HW accelerated decoder's supported profiles do not exactly match the stream", 0, AV_OPT_TYPE_CONST, {.i64 = AV_HWACCEL_FLAG_ALLOW_PROFILE_MISMATCH }, INT_MIN, INT_MAX, V | D, "hwaccel_flags"},
 {"extra_hw_frames", "Number of extra hardware frames to allocate for the user", OFFSET(extra_hw_frames), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, INT_MAX, V|D },
 {"discard_damaged_percentage", "Percentage of damaged samples to discard a frame", OFFSET(discard_damaged_percentage), AV_OPT_TYPE_INT, {.i64 = 95 }, 0, 100, V|D },
+{"sfc_flags", "set sfc flags", OFFSET(sfc_flags), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, 1, V|D, "sfc"},
+{"sfc_format", "set sfc format", OFFSET(sfc_format), AV_OPT_TYPE_PIXEL_FMT, {.i64=AV_PIX_FMT_ARGB}, -1, INT_MAX, V|D, "sfc"},
+{"sfc_width", "set sfc width", OFFSET(sfc_width), AV_OPT_TYPE_INT, {.i64 = 480}, 0, INT_MAX, V|D, "sfc"},
+{"sfc_height", "set sfc height", OFFSET(sfc_height), AV_OPT_TYPE_INT, {.i64 = 360}, 0, INT_MAX, V|D, "sfc"},
 {NULL},
 };
 

--- a/libavcodec/vaapi_decode.h
+++ b/libavcodec/vaapi_decode.h
@@ -37,6 +37,29 @@ static inline VASurfaceID ff_vaapi_get_surface_id(AVFrame *pic)
     return (uintptr_t)pic->data[3];
 }
 
+static inline VASurfaceID ff_vaapi_get_sfc_surface_id(AVFrame *pic)
+{
+    VASurfaceID sfc_surface_id = VA_INVALID_ID;
+
+    AVFrameSideData *frame_sfc_sd = av_frame_get_side_data(pic,
+                                                           AV_FRAME_DATA_SFC_INFO);
+    if (frame_sfc_sd) {
+        sfc_surface_id = (uintptr_t)frame_sfc_sd->buf->data;
+    }
+
+    return sfc_surface_id;
+}
+
+static inline int ff_vaapi_get_sfc_src_width(AVFrame *pic)
+{
+    return pic->width;
+}
+
+static inline int ff_vaapi_get_sfc_src_height(AVFrame *pic)
+{
+    return pic->height;
+}
+
 enum {
     MAX_PARAM_BUFFERS = 16,
 };
@@ -50,6 +73,13 @@ typedef struct VAAPIDecodePicture {
     int                nb_slices;
     VABufferID           *slice_buffers;
     int                   slices_allocated;
+
+    //sfc info
+    VASurfaceID           sfc_output_surface;
+    int                   sfc_src_width;
+    int                   sfc_src_height;
+    VABufferID            sfc_buffer;
+
 } VAAPIDecodePicture;
 
 typedef struct VAAPIDecodeContext {

--- a/libavcodec/vaapi_h264.c
+++ b/libavcodec/vaapi_h264.c
@@ -302,6 +302,19 @@ static int vaapi_h264_start_frame(AVCodecContext          *avctx,
     if (err < 0)
         goto fail;
 
+    //get sfc surface id
+    if (avctx->sfc_flags) {
+        pic->sfc_output_surface = ff_vaapi_get_sfc_surface_id(h->cur_pic_ptr->f);
+
+        //get sfc src width and height
+        pic->sfc_src_width = ff_vaapi_get_sfc_src_width(h->cur_pic_ptr->f);
+        pic->sfc_src_height = ff_vaapi_get_sfc_src_height(h->cur_pic_ptr->f);
+
+        av_log(avctx, AV_LOG_DEBUG, "H264 get sfc surface id: %d\n", pic->sfc_output_surface);
+        av_log(avctx, AV_LOG_DEBUG, "H264 get sfc width: %d\n", pic->sfc_src_width);
+        av_log(avctx, AV_LOG_DEBUG, "H264 get sfc height: %d\n", pic->sfc_src_height);
+    }
+
     return 0;
 
 fail:

--- a/libavutil/frame.c
+++ b/libavutil/frame.c
@@ -842,6 +842,7 @@ const char *av_frame_side_data_name(enum AVFrameSideDataType type)
 #endif
     case AV_FRAME_DATA_DYNAMIC_HDR_PLUS: return "HDR Dynamic Metadata SMPTE2094-40 (HDR10+)";
     case AV_FRAME_DATA_REGIONS_OF_INTEREST: return "Regions Of Interest";
+    case AV_FRAME_DATA_SFC_INFO: return "SFC Information";
     }
     return NULL;
 }

--- a/libavutil/frame.h
+++ b/libavutil/frame.h
@@ -179,6 +179,11 @@ enum AVFrameSideDataType {
      * array element is implied by AVFrameSideData.size / AVRegionOfInterest.self_size.
      */
     AV_FRAME_DATA_REGIONS_OF_INTEREST,
+
+    /**
+     * VDENC SFC information.
+     */
+    AV_FRAME_DATA_SFC_INFO,
 };
 
 enum AVActiveFormatDescription {
@@ -234,6 +239,14 @@ typedef struct AVRegionOfInterest {
     int right;
     AVRational qoffset;
 } AVRegionOfInterest;
+
+/**
+ * Structure to hold Information of SFC.
+ *
+ */
+typedef struct AVSFCInfo {
+    uint8_t *data;
+} AVSFCInfo;
 
 /**
  * This structure describes decoded (raw) audio or video data.

--- a/libavutil/hwcontext_vaapi.h
+++ b/libavutil/hwcontext_vaapi.h
@@ -100,6 +100,12 @@ typedef struct AVVAAPIFramesContext {
      */
     VASurfaceID     *surface_ids;
     int           nb_surfaces;
+
+    // VSFC info
+    int sfc_flags;
+    int sfc_format;
+    int sfc_width;
+    int sfc_height;
 } AVVAAPIFramesContext;
 
 /**


### PR DESCRIPTION
1. AVDictinary carrys sfc flags/width/height/format
2. Sidedata carrys sfc surface id

Signed-off-by: Zachary Zhou <zachary.zhou@intel.com>