### PR TITLE
lavc/qsvenc: Fix the memory leak for enc_ctrl.Payload

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1307,7 +1307,6 @@ static int encode_frame(AVCodecContext *avctx, QSVEncContext *q,
     if (qsv_frame) {
         surf = &qsv_frame->surface;
         enc_ctrl = &qsv_frame->enc_ctrl;
-        memset(enc_ctrl, 0, sizeof(mfxEncodeCtrl));
 
         if (frame->pict_type == AV_PICTURE_TYPE_I) {
             enc_ctrl->FrameType = MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF;


### PR DESCRIPTION
frame->enc_ctrl.Payload is malloced in get_free_frame, directly memset
the whole structure of enc_ctrl to zero will cause the memory leak for
enc_ctrl.Payload.

Fix the memory leak issue and reset other members in mfxEncodeCtrl.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>