### PR TITLE
lavu/hwcontext_qsv: Fix the realign check for hwupload

### DIFF
--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -892,7 +892,8 @@ static int qsv_transfer_data_to(AVHWFramesContext *ctx, AVFrame *dst,
         return ret;
 
 
-    if (src->height & 16 || src->linesize[0] & 16) {
+    if (src->height % 16 || src->width % 16 ||
+                            src->linesize[0] % 16) {
         realigned = 1;
         memset(&tmp_frame, 0, sizeof(tmp_frame));
         tmp_frame.format         = src->format;


### PR DESCRIPTION
Fix the aligned check in hwupload, input surface should be 16 aligned
too.

Fix #7830.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>