### PR TITLE
lavc/vaapi_encode_h264: add support for maxframesize

### DIFF
--- a/libavcodec/vaapi_encode.h
+++ b/libavcodec/vaapi_encode.h
@@ -176,6 +176,15 @@ typedef struct VAAPIEncodeContext {
     // Desired B frame reference depth.
     int             desired_b_depth;
 
+    // Max Frame Size
+    int             max_frame_size;
+    // Number Of Passes
+    int             pass_num;
+    // Delta_qp For Each Pass
+    int             delta_qp;
+    // Array of delta_qp
+    uint8_t         *delta_qp_array;
+
     // Explicitly set RC mode (otherwise attempt to pick from
     // available modes).
     int             explicit_rc_mode;
@@ -267,7 +276,12 @@ typedef struct VAAPIEncodeContext {
         VAEncMiscParameterBufferQualityLevel quality;
     } quality_params;
 #endif
-
+#if VA_CHECK_VERSION(1, 3, 0)
+    struct {
+        VAEncMiscParameterBuffer misc;
+        VAEncMiscParameterBufferMultiPassFrameSize mfs;
+    } __attribute__((packed)) mfs_params;
+#endif
     // Per-sequence parameter structure (VAEncSequenceParameterBuffer*).
     void           *codec_sequence_params;
 

--- a/libavcodec/vaapi_encode_h264.c
+++ b/libavcodec/vaapi_encode_h264.c
@@ -72,6 +72,9 @@ typedef struct VAAPIEncodeH264Context {
     int sei;
     int profile;
     int level;
+    int max_frame_size;
+    int pass_num;
+    int delta_qp;
 
     // Derived settings.
     int mb_width;
@@ -1233,6 +1236,12 @@ static av_cold int vaapi_encode_h264_init(AVCodecContext *avctx)
     if (priv->qp > 0)
         ctx->explicit_qp = priv->qp;
 
+    if (priv->max_frame_size > 0) {
+        ctx->max_frame_size = priv->max_frame_size;
+        ctx->pass_num       = priv->pass_num;
+        ctx->delta_qp       = priv->delta_qp;
+    }
+
     return ff_vaapi_encode_init(avctx);
 }
 
@@ -1266,6 +1275,12 @@ static const AVOption vaapi_encode_h264_options[] = {
 
     { "aud", "Include AUD",
       OFFSET(aud), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS },
+    { "max_frame_size", "Maximum frame size (in bytes)",
+      OFFSET(max_frame_size), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, FLAGS },
+    { "pass_num", "number of passes, every pass can have different QP, currently can support up to 4 passes",
+      OFFSET(pass_num), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, 4, FLAGS },
+    { "delta_qp", "delta QP for every pass",
+      OFFSET(delta_qp), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, 51, FLAGS },
 
     { "sei", "Set SEI to include",
       OFFSET(sei), AV_OPT_TYPE_FLAGS,


### PR DESCRIPTION
Add -max_frame_size (bytes) to indicate the allowed max frame size.

Currently only AVC encoder can support this settings in multiple pass case.
If the frame size exceeds, the encoder will do more pak passes to adjust the
QP value to control the frame size.

Set Default num_passes to 4 (1~4), set delta_qp[4] = {1, 1, 1, 1}, use
new_qp for encoder if frame size exceeds the limitation:
    new_qp = base_qp + delta_qp[0] + delta_qp[1] + ...

Signed-off-by: Linjie Fu <linjie.fu@intel.com>