### PR TITLE
lavc/vaapi_encode: grow packet if vaMapBuffer returns multiple buffers

### DIFF
--- a/libavcodec/vaapi_encode.c
+++ b/libavcodec/vaapi_encode.c
@@ -489,6 +489,8 @@ static int vaapi_encode_output(AVCodecContext *avctx,
     VAAPIEncodeContext *ctx = avctx->priv_data;
     VACodedBufferSegment *buf_list, *buf;
     VAStatus vas;
+    int total_size = 0;
+    uint8_t *ptr;
     int err;
 
     err = vaapi_encode_wait(avctx, pic);
@@ -505,15 +507,21 @@ static int vaapi_encode_output(AVCodecContext *avctx,
         goto fail;
     }
 
+    for (buf = buf_list; buf; buf = buf->next)
+        total_size += buf->size;
+
+    err = av_new_packet(pkt, total_size);
+    ptr = pkt->data;
+
+    if (err < 0)
+        goto fail_mapped;
+
     for (buf = buf_list; buf; buf = buf->next) {
         av_log(avctx, AV_LOG_DEBUG, "Output buffer: %u bytes "
                "(status %08x).\n", buf->size, buf->status);
 
-        err = av_new_packet(pkt, buf->size);
-        if (err < 0)
-            goto fail_mapped;
-
-        memcpy(pkt->data, buf->buf, buf->size);
+        memcpy(ptr, buf->buf, buf->size);
+        ptr += buf->size;
     }
 
     if (pic->type == PICTURE_TYPE_IDR)


### PR DESCRIPTION
It seems that VA_CODED_BUF_STATUS_SINGLE_NALU allows driver to map
buffer for each slice.

Currently, assigning new buffer for pkt when multiple buffer returns
from vaMapBuffer will cover the previous encoded pkt data and lead
to encode issues.

Using av_grow_packet to expand pkt if several buffers are returned.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>