### PR TITLE
lavc/vp9dec: fix the multi-thread HWAccel decode error

### DIFF
--- a/libavcodec/decode.h
+++ b/libavcodec/decode.h
@@ -76,6 +76,13 @@ void ff_decode_bsfs_uninit(AVCodecContext *avctx);
 int ff_decode_get_hw_frames_ctx(AVCodecContext *avctx,
                                 enum AVHWDeviceType dev_type);
 
+/**
+ * Get new hw_frames_ctx even if the context is aread initialized.
+ * Similar to ff_decode_get_hw_frames_ctx.
+ */
+int ff_decode_get_new_hw_frames_ctx(AVCodecContext *avctx,
+                                enum AVHWDeviceType dev_type);
+
 int ff_attach_decode_data(AVFrame *frame);
 
 #endif /* AVCODEC_DECODE_H */

--- a/libavcodec/internal.h
+++ b/libavcodec/internal.h
@@ -162,6 +162,13 @@ typedef struct AVCodecInternal {
 
     void *thread_ctx;
 
+    /**
+     * User thread AVCodecContext pointer and
+     * context mutex
+     */
+    void *user_avctx;
+    pthread_mutex_t context_mutex;
+
     DecodeSimpleContext ds;
     DecodeFilterContext filter;
 

--- a/libavcodec/vaapi_decode.c
+++ b/libavcodec/vaapi_decode.c
@@ -613,8 +613,10 @@ int ff_vaapi_decode_init(AVCodecContext *avctx)
     VAStatus vas;
     int err;
 
-    ctx->va_config  = VA_INVALID_ID;
-    ctx->va_context = VA_INVALID_ID;
+    if (!ctx->va_config && !ctx->va_context){
+        ctx->va_config  = VA_INVALID_ID;
+        ctx->va_context = VA_INVALID_ID;
+    }
 
 #if FF_API_STRUCT_VAAPI_CONTEXT
     if (avctx->hwaccel_context) {
@@ -642,7 +644,6 @@ int ff_vaapi_decode_init(AVCodecContext *avctx)
         // present, so set it here to avoid the behaviour changing.
         ctx->hwctx->driver_quirks =
             AV_VAAPI_DRIVER_QUIRK_RENDER_PARAM_BUFFERS;
-
     }
 #endif
 
@@ -655,10 +656,16 @@ int ff_vaapi_decode_init(AVCodecContext *avctx)
                "context: %#x/%#x.\n", ctx->va_config, ctx->va_context);
     } else {
 #endif
-
-    err = ff_decode_get_hw_frames_ctx(avctx, AV_HWDEVICE_TYPE_VAAPI);
-    if (err < 0)
-        goto fail;
+    if (!avctx->hw_frames_ctx) {
+        err = ff_decode_get_hw_frames_ctx(avctx, AV_HWDEVICE_TYPE_VAAPI);
+        if (err < 0)
+            goto fail;
+    } else {
+    // get new surface for these resolution changed cases
+        err = ff_decode_get_new_hw_frames_ctx(avctx, AV_HWDEVICE_TYPE_VAAPI);
+        if (err < 0)
+            goto fail;
+    }
 
     ctx->frames = (AVHWFramesContext*)avctx->hw_frames_ctx->data;
     ctx->hwfc   = ctx->frames->hwctx;
@@ -670,21 +677,23 @@ int ff_vaapi_decode_init(AVCodecContext *avctx)
     if (err)
         goto fail;
 
-    vas = vaCreateContext(ctx->hwctx->display, ctx->va_config,
-                          avctx->coded_width, avctx->coded_height,
-                          VA_PROGRESSIVE,
-                          ctx->hwfc->surface_ids,
-                          ctx->hwfc->nb_surfaces,
-                          &ctx->va_context);
-    if (vas != VA_STATUS_SUCCESS) {
-        av_log(avctx, AV_LOG_ERROR, "Failed to create decode "
-               "context: %d (%s).\n", vas, vaErrorStr(vas));
-        err = AVERROR(EIO);
-        goto fail;
-    }
+    if (ctx->va_context == VA_INVALID_ID) {
+        vas = vaCreateContext(ctx->hwctx->display, ctx->va_config,
+                              avctx->coded_width, avctx->coded_height,
+                              VA_PROGRESSIVE,
+                              ctx->hwfc->surface_ids,
+                              ctx->hwfc->nb_surfaces,
+                              &ctx->va_context);
+        if (vas != VA_STATUS_SUCCESS) {
+            av_log(avctx, AV_LOG_ERROR, "Failed to create decode "
+                   "context: %d (%s).\n", vas, vaErrorStr(vas));
+            err = AVERROR(EIO);
+            goto fail;
+        }
 
-    av_log(avctx, AV_LOG_DEBUG, "Decode context initialised: "
-           "%#x/%#x.\n", ctx->va_config, ctx->va_context);
+        av_log(avctx, AV_LOG_DEBUG, "Decode context initialised: "
+               "%#x/%#x.\n", ctx->va_config, ctx->va_context);
+    }
 #if FF_API_STRUCT_VAAPI_CONTEXT
     }
 #endif


### PR DESCRIPTION
Fix the multi-thread HWAccel decode error for vp9.

VP9 supports the resolution changing. In multi-thread mode, worker-threads
destroy and free the first created VAAPIDecodeContext if resolution change
happens and create new one. Other threads still request to destroy previous
and demand for new context. This leads to decode failures and memory issue.

Modify to call hwaccel_uninit/hwaccel_init by ff_thread_get_format only
when the first-come thread detected the resolution changing.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>