### PR TITLE
lavc/vaapi_encode_h264: add support for maxframesize

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -2899,6 +2899,12 @@ will refer only to P- or I-frames.  When set to greater values multiple layers
 of B-frames will be present, frames in each layer only referring to frames in
 higher layers.
 
+@item max_frame_size
+Set the allowed max size in bytes for each frame. If the frame size exceeds
+the limitation, encoder will adjust the QP value by adding delta_qp for each 
+pass to control the frame size. To simplify the usage, delta_qp is set to
+default.
+
 @item rc_mode
 Set the rate control mode to use.  A given driver may only support a subset of
 modes.

--- a/libavcodec/vaapi_encode.c
+++ b/libavcodec/vaapi_encode.c
@@ -258,7 +258,16 @@ static int vaapi_encode_issue(AVCodecContext *avctx,
         if (err < 0)
             goto fail;
     }
-
+#if VA_CHECK_VERSION(1, 5, 0)
+    if (ctx->max_frame_size) {
+        err = vaapi_encode_make_misc_param_buffer(avctx, pic,
+                                            VAEncMiscParameterTypeMultiPassFrameSize,
+                                            &ctx->mfs_params,
+                                            sizeof(ctx->mfs_params));
+        if (err < 0)
+            goto fail;
+    }
+#endif
     if (pic->type == PICTURE_TYPE_IDR) {
         if (ctx->va_packed_headers & VA_ENC_PACKED_HEADER_SEQUENCE &&
             ctx->codec->write_sequence_header) {
@@ -1671,6 +1680,54 @@ rc_mode_found:
     return 0;
 }
 
+static av_cold int vaapi_encode_init_max_frame_size(AVCodecContext *avctx)
+{
+#if VA_CHECK_VERSION(1, 5, 0)
+    VAAPIEncodeContext  *ctx = avctx->priv_data;
+    VAConfigAttrib      attr = { VAConfigAttribMaxFrameSize };
+    VAStatus vas;
+    int i;
+
+    vas = vaGetConfigAttributes(ctx->hwctx->display,
+                                    ctx->va_profile,
+                                    ctx->va_entrypoint,
+                                    &attr, 1);
+    if (vas != VA_STATUS_SUCCESS) {
+        ctx->max_frame_size = 0;
+        av_log(avctx, AV_LOG_ERROR, "Failed to query max frame size "
+               "config attribute: %d (%s).\n", vas, vaErrorStr(vas));
+        return AVERROR_EXTERNAL;
+    }
+
+    if (attr.value == VA_ATTRIB_NOT_SUPPORTED) {
+        ctx->max_frame_size = 0;
+        av_log(avctx, AV_LOG_WARNING, "Max frame size attribute "
+                                                "is not supported.\n");
+    } else {
+        ctx->delta_qp = av_mallocz_array(MFS_NUM_PASSES, sizeof(uint8_t));
+        if (!ctx->delta_qp) {
+            return AVERROR(ENOMEM);
+        }
+        for (i = 0; i <MFS_NUM_PASSES; i++)
+            ctx->delta_qp[i] = MFS_DELTA_QP;
+        
+        ctx->mfs_params = (VAEncMiscParameterBufferMultiPassFrameSize){
+            .max_frame_size = ctx->max_frame_size,
+            .num_passes     = MFS_NUM_PASSES,
+            .delta_qp       = ctx->delta_qp,
+        };
+
+        av_log(avctx, AV_LOG_VERBOSE, "Max Frame Size: %d bytes.\n ",
+                                                        ctx->max_frame_size);
+    }
+#else
+    av_log(avctx, AV_LOG_WARNING, "Max Frame Size is "
+                                    "not supported with this VA version.\n");
+#endif
+
+    return 0;
+}
+
 static av_cold int vaapi_encode_init_gop_structure(AVCodecContext *avctx)
 {
     VAAPIEncodeContext *ctx = avctx->priv_data;
@@ -2138,6 +2195,12 @@ av_cold int ff_vaapi_encode_init(AVCodecContext *avctx)
             goto fail;
     }
 
+    if (ctx->max_frame_size) {
+        err = vaapi_encode_init_max_frame_size(avctx);
+        if (err < 0)
+            goto fail;
+    }
+
     vas = vaCreateConfig(ctx->hwctx->display,
                          ctx->va_profile, ctx->va_entrypoint,
                          ctx->config_attributes, ctx->nb_config_attributes,
@@ -2261,6 +2324,9 @@ av_cold int ff_vaapi_encode_close(AVCodecContext *avctx)
         vaDestroyConfig(ctx->hwctx->display, ctx->va_config);
         ctx->va_config = VA_INVALID_ID;
     }
+
+    if (ctx->delta_qp)
+        av_freep(&ctx->delta_qp);
 
     av_freep(&ctx->codec_sequence_params);
     av_freep(&ctx->codec_picture_params);

--- a/libavcodec/vaapi_encode.h
+++ b/libavcodec/vaapi_encode.h
@@ -51,6 +51,11 @@ enum {
     PICTURE_TYPE_B   = 3,
 };
 
+enum {
+    MFS_NUM_PASSES = 4,
+    MFS_DELTA_QP   = 1,
+};
+
 typedef struct VAAPIEncodeSlice {
     int             index;
     int             row_start;
@@ -176,6 +181,9 @@ typedef struct VAAPIEncodeContext {
     // Desired B frame reference depth.
     int             desired_b_depth;
 
+    // Max Frame Size
+    int             max_frame_size;
+
     // Explicitly set RC mode (otherwise attempt to pick from
     // available modes).
     int             explicit_rc_mode;
@@ -256,7 +264,9 @@ typedef struct VAAPIEncodeContext {
 #if VA_CHECK_VERSION(0, 36, 0)
     VAEncMiscParameterBufferQualityLevel quality_params;
 #endif
-
+#if VA_CHECK_VERSION(1, 3, 0)
+    VAEncMiscParameterBufferMultiPassFrameSize mfs_params;
+#endif
     // Per-sequence parameter structure (VAEncSequenceParameterBuffer*).
     void           *codec_sequence_params;
 
@@ -303,6 +313,7 @@ typedef struct VAAPIEncodeContext {
     int idr_counter;
     int gop_counter;
     int end_of_stream;
+    uint8_t *delta_qp;
 
     // The encoder does not support cropping information, so warn about
     // it the first time we encounter any nonzero crop fields.
@@ -418,7 +429,11 @@ int ff_vaapi_encode_close(AVCodecContext *avctx);
     { "b_depth", \
       "Maximum B-frame reference depth", \
       OFFSET(common.desired_b_depth), AV_OPT_TYPE_INT, \
-      { .i64 = 1 }, 1, INT_MAX, FLAGS }
+      { .i64 = 1 }, 1, INT_MAX, FLAGS }, \
+    { "max_frame_size", \
+      "Maximum frame size (in bytes)",\
+      OFFSET(common.max_frame_size), AV_OPT_TYPE_INT, \
+      { .i64 = 0 }, 0, INT_MAX, FLAGS }
 
 #define VAAPI_ENCODE_RC_MODE(name, desc) \
     { #name, desc, 0, AV_OPT_TYPE_CONST, { .i64 = RC_MODE_ ## name }, \


### PR DESCRIPTION
Add support for max frame size:
    - max_frame_size (bytes) to indicate the allowed max frame size.
    - pass_num to indicate number of passes for QP adjust.
    - delta_qp to indicate adjust qp value per pass.

Currently only AVC encoder can support this settings in multiple pass case.
If the frame size exceeds, the encoder will do more pak passes to adjust the
QP value to control the frame size.

Set Default num_passes to 4 (1~4), set delta_qp[4] = {1, 1, 1, 1}, use
new_qp for encoder if frame size exceeds the limitation:
    new_qp = base_qp + delta_qp[0] + delta_qp[1] + ...

ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -f rawvideo \
        -v verbose -s:v 352x288 -i ./input.yuv -vf format=nv12,hwupload \
        -c:v h264_vaapi -profile:v main -g 30 -bf 3 -max_frame_size 40000 \
        -pass_num 2 -delta_qp 2 -vframes 100 -y ./max_frame_size.h264

Signed-off-by: Linjie Fu <linjie.fu@intel.com>