### PR TITLE
lavu/hwcontext_qsv: fix the memory leak

### DIFF
--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -1240,6 +1240,8 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
 
     ret = av_hwdevice_ctx_create(&priv->child_device_ctx, child_device_type,
                                  e ? e->value : NULL, child_device_opts, 0);
+
+    av_dict_free(&child_device_opts);
     if (ret < 0)
         return ret;
 


### PR DESCRIPTION
av_dict_free child_device_opts to fix the memory leak.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>