### PR TITLE
lavu/hwcontext_vaapi: cope with race condition when map from pixfmt t…

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -63,6 +63,7 @@ typedef struct VAAPIDevicePriv {
 typedef struct VAAPISurfaceFormat {
     enum AVPixelFormat pix_fmt;
     VAImageFormat image_format;
+    unsigned int fourcc;
 } VAAPISurfaceFormat;
 
 typedef struct VAAPIDeviceContext {
@@ -171,15 +172,21 @@ static int vaapi_get_image_format(AVHWDeviceContext *hwdev,
                                   VAImageFormat **image_format)
 {
     VAAPIDeviceContext *ctx = hwdev->internal->priv;
+    VAAPIFormatDescriptor *desc;
     int i;
 
+    desc = vaapi_format_from_pix_fmt(pix_fmt);
+    if (!desc || !image_format)
+        goto fail;
+
     for (i = 0; i < ctx->nb_formats; i++) {
-        if (ctx->formats[i].pix_fmt == pix_fmt) {
-            if (image_format)
-                *image_format = &ctx->formats[i].image_format;
+        if (ctx->formats[i].fourcc == desc->fourcc) {
+            *image_format = &ctx->formats[i].image_format;
             return 0;
         }
     }
+
+fail:
     return AVERROR(EINVAL);
 }
 
@@ -368,6 +375,7 @@ static int vaapi_device_init(AVHWDeviceContext *hwdev)
             av_log(hwdev, AV_LOG_DEBUG, "Format %#x -> %s.\n",
                    fourcc, av_get_pix_fmt_name(pix_fmt));
             ctx->formats[ctx->nb_formats].pix_fmt      = pix_fmt;
+            ctx->formats[ctx->nb_formats].fourcc       = fourcc;
             ctx->formats[ctx->nb_formats].image_format = image_list[i];
             ++ctx->nb_formats;
         }


### PR DESCRIPTION
Fix issue:

ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v debug -f rawvideo -pix_fmt nv12 -s:v 1280x720 -i ./720p5994_parkrun_ter_1280x720_NV12.yuv -vf 'format=nv12,hwupload,scale_vaapi=format=yuv420p,hwdownload,format=yuv420p' -f null -

race condition for YUV420P in map from pixfmt to fourcc in vaapi_frames_init.

desc = vaapi_format_from_pix_fmt(hwfc->sw_format);
