### PR TITLE
lavc/qsvdec: cope with unknown profile for HEVC

### DIFF
--- a/libavcodec/qsv_internal.h
+++ b/libavcodec/qsv_internal.h
@@ -89,7 +89,7 @@ int ff_qsv_print_warning(void *log_ctx, mfxStatus err,
                          const char *warning_string);
 
 int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id);
-int ff_qsv_profile_to_mfx(enum AVCodecID codec_id, int profile);
+int ff_qsv_profile_to_mfx(AVCodecContext *avctx);
 int ff_qsv_level_to_mfx(enum AVCodecID codec_id, int level);
 
 int ff_qsv_map_pixfmt(enum AVPixelFormat format, uint32_t *fourcc);

--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -202,7 +202,7 @@ static int qsv_decode_init(AVCodecContext *avctx, QSVContext *q)
         return ret;
 
     param.mfx.CodecId      = ret;
-    param.mfx.CodecProfile = ff_qsv_profile_to_mfx(avctx->codec_id, avctx->profile);
+    param.mfx.CodecProfile = ff_qsv_profile_to_mfx(avctx);
     param.mfx.CodecLevel   = ff_qsv_level_to_mfx(avctx->codec_id, avctx->level);
 
     param.mfx.FrameInfo.BitDepthLuma   = desc->comp[0].depth;


### PR DESCRIPTION
Currently, unknown profile will cause the decode failure directly in
qsv.

Add a more compatible path to cope with the unknown profile. If
AV_HWACCEL_FLAG_ALLOW_PROFILE_MISMATCH flag is set, decoder will try
default mfx_profile for unknown profile and bump a warning message.

cmdline:
    ffmpeg ... -hwaccel_flags allow_profile_mismatch ...

Also modify in qsv_profile_map[] to make the code look more neat.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>