### PR TITLE
lavc/qsv: fix a memory leak in ff_qsv_set_display_handle()

### DIFF
--- a/libavcodec/qsv.c
+++ b/libavcodec/qsv.c
@@ -838,6 +838,8 @@ int ff_qsv_close_internal_session(QSVSession *qs)
     if (qs->va_device_ctx) {
         qs->va_device_ctx->free(qs->va_device_ctx);
     }
+
+    av_buffer_unref(&qs->va_device_ref);
 #endif
     return 0;
 }


### PR DESCRIPTION
Reported-by: Linjie Fu <linjie.fu@intel.com>
Signed-off-by: Zhong Li <zhong.li@intel.com>