### PR TITLE
lavc/qsv: add use_raw_ref option for h264_qsv encoder

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -505,6 +505,18 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
     } else
         q->param.mfx.LowPower = MFX_CODINGOPTION_OFF;
 
+    if (q->use_raw_ref) {
+#if QSV_HAVE_CO2_URR
+        q->extco2.UseRawRef = MFX_CODINGOPTION_ON;
+#else
+        av_log(avctx, AV_LOG_WARNING, "The use_raw_ref option is "
+                            "not supported with this MSDK version.\n");
+        q->use_raw_ref = 0;
+        q->extco2.UseRawRef = MFX_CODINGOPTION_OFF;
+#endif
+    } else
+        q->extco2.UseRawRef = MFX_CODINGOPTION_OFF;
+
     q->param.mfx.CodecProfile       = q->profile;
     q->param.mfx.TargetUsage        = avctx->compression_level;
     q->param.mfx.GopPicSize         = FFMAX(0, avctx->gop_size);

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -45,6 +45,7 @@
 #define QSV_HAVE_LA     QSV_VERSION_ATLEAST(1, 7)
 #define QSV_HAVE_LA_DS  QSV_VERSION_ATLEAST(1, 8)
 #define QSV_HAVE_LA_HRD QSV_VERSION_ATLEAST(1, 11)
+#define QSV_HAVE_CO2_URR QSV_VERSION_ATLEAST(1, 13)
 #define QSV_HAVE_VDENC  QSV_VERSION_ATLEAST(1, 15)
 
 #define QSV_HAVE_GPB    QSV_VERSION_ATLEAST(1, 18)
@@ -176,6 +177,7 @@ typedef struct QSVEncContext {
     int repeat_pps;
     int low_power;
     int gpb;
+    int use_raw_ref;
 
     int a53_cc;
 

--- a/libavcodec/qsvenc_h264.c
+++ b/libavcodec/qsvenc_h264.c
@@ -150,6 +150,10 @@ static const AVOption options[] = {
 
     { "repeat_pps", "repeat pps for every frame", OFFSET(qsv.repeat_pps), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
 
+#if QSV_HAVE_CO2_URR
+    { "use_raw_ref", "Use raw frames for reference", OFFSET(qsv.use_raw_ref), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE },
+#endif
+
     { NULL },
 };
 


### PR DESCRIPTION
Enable using raw frame for reference in QSV h264 encoder.

This option will benefit the vedio quality under some special cases
like multi-texture and high motion blur video under low bit rate.

Signed-off-by: Xinpeng Sun <xinpeng.sun@intel.com>