### PR TITLE
lavc/qsv: add no_latency option for h264_qsv encoder

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -291,6 +291,10 @@ static int select_rc_mode(AVCodecContext *avctx, QSVEncContext *q)
     const char *rc_desc;
     mfxU16      rc_mode;
 
+    if (q->no_latency) {
+        q->look_ahead = 0;
+    }
+
     int want_la     = q->look_ahead;
     int want_qscale = !!(avctx->flags & AV_CODEC_FLAG_QSCALE);
     int want_vcm    = q->vcm;
@@ -504,6 +508,10 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
 #endif
     } else
         q->param.mfx.LowPower = MFX_CODINGOPTION_OFF;
+
+    if (q->no_latency) {
+        avctx->max_b_frames = 0;
+    }
 
     q->param.mfx.CodecProfile       = q->profile;
     q->param.mfx.TargetUsage        = avctx->compression_level;
@@ -999,6 +1007,10 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
     int iopattern = 0;
     int opaque_alloc = 0;
     int ret;
+
+    if (q->no_latency) {
+        q->async_depth = 1;
+    }
 
     q->param.AsyncDepth = q->async_depth;
 

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -157,6 +157,8 @@ typedef struct QSVEncContext {
 
     int aud;
 
+    int no_latency;
+
     int single_sei_nal_unit;
     int max_dec_frame_buffering;
 

--- a/libavcodec/qsvenc_h264.c
+++ b/libavcodec/qsvenc_h264.c
@@ -150,6 +150,8 @@ static const AVOption options[] = {
 
     { "repeat_pps", "repeat pps for every frame", OFFSET(qsv.repeat_pps), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
 
+    { "no_latency", "Turn off some options to encode with no latency", OFFSET(qsv.no_latency), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE },
+
     { NULL },
 };
 


### PR DESCRIPTION
look_ahead, async_depth and max_b_frames will be turned off
with this option on, and the latency of encoding will be 0.

Signed-off-by: Xinpeng Sun <xinpeng.sun@intel.com>