### PR TITLE
Pr qsvdec tiny resolution change

### DIFF
--- a/libavcodec/qsv.c
+++ b/libavcodec/qsv.c
@@ -401,7 +401,7 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
         ret = MFXVideoCORE_SetHandle(qs->session,
                 (mfxHandleType)MFX_HANDLE_VA_DISPLAY, (mfxHDL)hwctx->display);
         if (ret < 0) {
-            return ff_qsv_print_error(avctx, ret, "Error during set display handle\n");
+            return ff_qsv_print_error(avctx, ret, "Error during set display handle");
         }
     }
 

--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -468,7 +468,7 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
         ret != MFX_ERR_MORE_SURFACE) {
         av_freep(&sync);
         return ff_qsv_print_error(avctx, ret,
-                                  "Error during QSV decoding.");
+                                  "Error during QSV decoding");
     }
 
     /* make sure we do not enter an infinite loop if the SDK

--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -630,9 +630,6 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
 
         q->orig_pix_fmt = avctx->pix_fmt = pix_fmt = ff_qsv_map_fourcc(param.mfx.FrameInfo.FourCC);
 
-        avctx->coded_width  = param.mfx.FrameInfo.Width;
-        avctx->coded_height = param.mfx.FrameInfo.Height;
-
         ret = qsv_decode_preinit(avctx, q, pix_fmt, &param);
         if (ret < 0)
             goto reinit_fail;


### PR DESCRIPTION
1. Standardize some usages of ff_qsv_print_error 
2. Remove redundant settings for coded_width/height.
