### PR TITLE
lavu/hwcontext_vaapi: Check VA_SURFACE_ATTRIB_SETTABLE for attributes

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -507,10 +507,12 @@ static int vaapi_frames_init(AVHWFramesContext *hwfc)
             int need_memory_type = !(hwctx->driver_quirks & AV_VAAPI_DRIVER_QUIRK_ATTRIB_MEMTYPE);
             int need_pixel_format = 1;
             for (i = 0; i < avfc->nb_attributes; i++) {
-                if (avfc->attributes[i].type == VASurfaceAttribMemoryType)
-                    need_memory_type  = 0;
-                if (avfc->attributes[i].type == VASurfaceAttribPixelFormat)
-                    need_pixel_format = 0;
+                if (avfc->attributes[i].flags & VA_SURFACE_ATTRIB_SETTABLE) {
+                    if (avfc->attributes[i].type == VASurfaceAttribMemoryType)
+                        need_memory_type  = 0;
+                    if (avfc->attributes[i].type == VASurfaceAttribPixelFormat)
+                        need_pixel_format = 0;
+                }
             }
             ctx->nb_attributes =
                 avfc->nb_attributes + need_memory_type + need_pixel_format;


### PR DESCRIPTION
VASurfaceAttribPixelFormat is used to guarantee a proper fourcc or
media_format of the created surface.

If VA_SURFACE_ATTRIB_SETTABLE is not set, these attributes may be
ignored.

Add a check for attributes.flags when creating surface to make sure
these attribuates are truly accessible.

See:
https://github.com/intel/media-driver/blob/master/media_driver/linux/
common/ddi/media_libva.cpp#L2149

Signed-off-by: Linjie Fu <linjie.fu@intel.com>