### PR TITLE
avcodec/cbs_av1: rename enable_intraintra_compound flag

### DIFF
--- a/libavcodec/cbs_av1.c
+++ b/libavcodec/cbs_av1.c
@@ -1039,6 +1039,7 @@ static int cbs_av1_read_unit(CodedBitstreamContext *ctx,
 
     if (obu->obu_size > 0 &&
         obu->header.obu_type != AV1_OBU_TILE_GROUP &&
+        obu->header.obu_type != AV1_OBU_TILE_LIST &&
         obu->header.obu_type != AV1_OBU_FRAME) {
         int nb_bits = obu->obu_size * 8 + start_pos - end_pos;
 

--- a/libavcodec/cbs_av1.h
+++ b/libavcodec/cbs_av1.h
@@ -105,7 +105,7 @@ typedef struct AV1RawSequenceHeader {
     uint8_t use_128x128_superblock;
     uint8_t enable_filter_intra;
     uint8_t enable_intra_edge_filter;
-    uint8_t enable_intraintra_compound;
+    uint8_t enable_interintra_compound;
     uint8_t enable_masked_compound;
     uint8_t enable_warped_motion;
     uint8_t enable_dual_filter;

--- a/libavcodec/cbs_av1_syntax_template.c
+++ b/libavcodec/cbs_av1_syntax_template.c
@@ -268,7 +268,7 @@ static int FUNC(sequence_header_obu)(CodedBitstreamContext *ctx, RWContext *rw,
     flag(enable_intra_edge_filter);
 
     if (current->reduced_still_picture_header) {
-        infer(enable_intraintra_compound, 0);
+        infer(enable_interintra_compound, 0);
         infer(enable_masked_compound,     0);
         infer(enable_warped_motion,       0);
         infer(enable_dual_filter,         0);
@@ -281,7 +281,7 @@ static int FUNC(sequence_header_obu)(CodedBitstreamContext *ctx, RWContext *rw,
         infer(seq_force_integer_mv,
               AV1_SELECT_INTEGER_MV);
     } else {
-        flag(enable_intraintra_compound);
+        flag(enable_interintra_compound);
         flag(enable_masked_compound);
         flag(enable_warped_motion);
         flag(enable_dual_filter);

--- a/libavformat/av1.c
+++ b/libavformat/av1.c
@@ -257,7 +257,7 @@ static int parse_sequence_header(AV1SequenceParameters *seq_params, const uint8_
     if (!reduced_still_picture_header) {
         int enable_order_hint, seq_force_screen_content_tools;
 
-        skip_bits(&gb, 4); // enable_intraintra_compound (1), enable_masked_compound (1)
+        skip_bits(&gb, 4); // enable_interintra_compound (1), enable_masked_compound (1)
                            // enable_warped_motion (1), enable_dual_filter (1)
 
         enable_order_hint = get_bits1(&gb);


### PR DESCRIPTION
rename enable_intraintra_compound to enable_interintra_compound,
which keep same as AV1 sepc(v1.0.0-errata1).

Signed-off-by: Wangfei <fei.w.wang@intel.com>