### PR TITLE
avcodec/cbs_av1: avoid reading trailing bits when obu type is OBU_TIL…

### DIFF
--- a/libavcodec/cbs_av1.c
+++ b/libavcodec/cbs_av1.c
@@ -1039,6 +1039,7 @@ static int cbs_av1_read_unit(CodedBitstreamContext *ctx,
 
     if (obu->obu_size > 0 &&
         obu->header.obu_type != AV1_OBU_TILE_GROUP &&
+        obu->header.obu_type != AV1_OBU_TILE_LIST &&
         obu->header.obu_type != AV1_OBU_FRAME) {
         int nb_bits = obu->obu_size * 8 + start_pos - end_pos;
 


### PR DESCRIPTION
…E_LIST

Signed-off-by: Wangfei <fei.w.wang@intel.com>