### PR TITLE
avcodec/cbs_av1: avoid reset some members of loop filter

### DIFF
--- a/libavcodec/cbs_av1.h
+++ b/libavcodec/cbs_av1.h
@@ -444,6 +444,9 @@ typedef struct CodedBitstreamAV1Context {
     AV1ReferenceFrameState *ref;
     AV1ReferenceFrameState read_ref[AV1_NUM_REF_FRAMES];
     AV1ReferenceFrameState write_ref[AV1_NUM_REF_FRAMES];
+
+    int8_t pre_loop_filter_ref_deltas[AV1_TOTAL_REFS_PER_FRAME];
+    int8_t pre_loop_filter_mode_deltas[2];
 } CodedBitstreamAV1Context;
 
 

--- a/libavcodec/cbs_av1_syntax_template.c
+++ b/libavcodec/cbs_av1_syntax_template.c
@@ -819,6 +819,13 @@ static int FUNC(loop_filter_params)(CodedBitstreamContext *ctx, RWContext *rw,
     CodedBitstreamAV1Context *priv = ctx->priv_data;
     int i, err;
 
+    memcpy(current->loop_filter_ref_deltas,
+            priv->pre_loop_filter_ref_deltas,
+            AV1_TOTAL_REFS_PER_FRAME * sizeof(int8_t));
+    memcpy(current->loop_filter_mode_deltas,
+            priv->pre_loop_filter_mode_deltas,
+            2 * sizeof(int8_t));
+
     if (priv->coded_lossless || current->allow_intrabc) {
         infer(loop_filter_level[0], 0);
         infer(loop_filter_level[1], 0);
@@ -832,7 +839,12 @@ static int FUNC(loop_filter_params)(CodedBitstreamContext *ctx, RWContext *rw,
         infer(loop_filter_ref_deltas[AV1_REF_FRAME_ALTREF2], -1);
         for (i = 0; i < 2; i++)
             infer(loop_filter_mode_deltas[i], 0);
-        return 0;
+
+        memcpy(priv->pre_loop_filter_ref_deltas,
+                current->loop_filter_ref_deltas,
+                AV1_TOTAL_REFS_PER_FRAME * sizeof(int8_t));
+
+	return 0;
     }
 
     fb(6, loop_filter_level[0]);
@@ -864,6 +876,13 @@ static int FUNC(loop_filter_params)(CodedBitstreamContext *ctx, RWContext *rw,
             }
         }
     }
+
+    memcpy(priv->pre_loop_filter_ref_deltas,
+            current->loop_filter_ref_deltas,
+            AV1_TOTAL_REFS_PER_FRAME * sizeof(int8_t));
+    memcpy(priv->pre_loop_filter_mode_deltas,
+            current->loop_filter_mode_deltas,
+            2 * sizeof(int8_t));
 
     return 0;
 }


### PR DESCRIPTION
According AV1 spec 6.8.10, loop_filter_ref_deltas & loop_filter_mode_deltas
should be keep same as its previous value if it is not presented in current
syntax.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>