### PR TITLE
lavu/hwcontext_vaapi: remove redundant check in vaapi_map_to_memory

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -932,12 +932,6 @@ static int vaapi_map_to_memory(AVHWFramesContext *hwfc, AVFrame *dst,
 {
     int err;
 
-    if (dst->format != AV_PIX_FMT_NONE) {
-        err = vaapi_get_image_format(hwfc->device_ctx, dst->format, NULL);
-        if (err < 0)
-            return AVERROR(ENOSYS);
-    }
-
     err = vaapi_map_frame(hwfc, dst, src, flags);
     if (err)
         return err;


### PR DESCRIPTION
vaapi_get_image_format() will be called in vaapi_map_frame(), so it's
redundant here. Also, NULL for VAImageFormat **image_format could be
a bit improper since the function is supposed to be used to get the
image format.

Remove vaapi_get_image_format() in vaapi_map_to_memory().

Signed-off-by: Linjie Fu <linjie.fu@intel.com>