### PR TITLE
lavfi/vf_scale_qsv: add extra_hw_frames support

### DIFF
--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -205,6 +205,8 @@ static int init_out_pool(AVFilterContext *ctx,
     out_frames_ctx->height            = FFALIGN(out_height, 16);
     out_frames_ctx->sw_format         = out_format;
     out_frames_ctx->initial_pool_size = 4;
+    if (ctx->extra_hw_frames > 0)
+            out_frames_ctx->initial_pool_size += ctx->extra_hw_frames;
 
     out_frames_hwctx->frame_type = in_frames_hwctx->frame_type;
 


### PR DESCRIPTION
While using scale_qsv together with lookahead, extra_hw_frames is
required to allocate more memory.

Fix #8379.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>