### PR TITLE
lavfi/vf_vpp_qsv: fix the infinite loop while framerate lower than input

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -476,6 +476,9 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *picref)
 
     if (vpp->qsv) {
         ret = ff_qsvvpp_filter_frame(vpp->qsv, inlink, picref);
+        /* ignore the EAGAIN caused by frame dropping in frc */
+        if (ret == AVERROR(EAGAIN))
+            ret = av_cmp_q(vpp->framerate, inlink->frame_rate) < 0 ? 0 : ret;
         av_frame_free(&picref);
     } else {
         if (picref->pts != AV_NOPTS_VALUE)


### PR DESCRIPTION
There are frame droppings in frc while converting into a lower framerate,
and MSDK returns ERROR_MORE_DATA, which could be ignored.

Reported-by: Gupta, Pallavi <pallavi.gupta@intel.com>
Signed-off-by: Linjie Fu <linjie.fu@intel.com>