### PR TITLE
lavc/vaapi_encode_h265: add forced_bframe option for internal use only

### DIFF
--- a/libavcodec/vaapi_encode_h265.c
+++ b/libavcodec/vaapi_encode_h265.c
@@ -445,8 +445,9 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
     sps->log2_min_luma_transform_block_size_minus2   = 0;
     sps->log2_diff_max_min_luma_transform_block_size = 3;
     // Full transform hierarchy allowed (2-5).
-    sps->max_transform_hierarchy_depth_inter = 3;
-    sps->max_transform_hierarchy_depth_intra = 3;
+    // Default to 2 based on Programmer's Reference Manuals of Intel graphics
+    sps->max_transform_hierarchy_depth_inter = 2;
+    sps->max_transform_hierarchy_depth_intra = 2;
     // AMP works.
     sps->amp_enabled_flag = 1;
     // SAO and temporal MVP do not work.


### PR DESCRIPTION
Internal use only.

Needs to query driver caps and provide p/b frame usage information at least.

Signed-off-by: Linjie Fu <linjie.fu@intel.com>