### PR TITLE
dnn/native: fix typo for definition of DOT_INTERMEDIATE

### DIFF
--- a/libavfilter/dnn/dnn_backend_native.h
+++ b/libavfilter/dnn/dnn_backend_native.h
@@ -46,7 +46,7 @@ typedef enum {
     DLT_COUNT
 } DNNLayerType;
 
-typedef enum {DOT_INPUT = 1, DOT_OUTPUT = 2, DOT_INTERMEDIATE = DOT_INPUT | DOT_INPUT} DNNOperandType;
+typedef enum {DOT_INPUT = 1, DOT_OUTPUT = 2, DOT_INTERMEDIATE = DOT_INPUT | DOT_OUTPUT} DNNOperandType;
 
 typedef struct Layer{
     DNNLayerType type;


### PR DESCRIPTION
Signed-off-by: Wu Zhiwen <zhiwen.wu@intel.com>
Reviewed-by: Guo Yejun <yejun.guo@intel.com>