### PR TITLE
lavu/hwcontext_qsv: add 10-bit RGB support for QSV

### DIFF
--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -110,6 +110,10 @@ static const struct {
 #if CONFIG_VAAPI
     { AV_PIX_FMT_YUYV422,
                        MFX_FOURCC_YUY2 },
+#if QSV_VERSION_ATLEAST(1, 9)
+    { AV_PIX_FMT_X2RGB10,
+                    MFX_FOURCC_A2RGB10 },
+#endif
 #if QSV_VERSION_ATLEAST(1, 27)
     { AV_PIX_FMT_Y210,
                        MFX_FOURCC_Y210 },


### PR DESCRIPTION
Command line for CSC:
ffmpeg -hwaccel qsv -v verbose -c:v hevc_qsv -i
    p010.h265 -vf scale_qsv=format=x2rgb10,hwdownload,format=x2rgb10
    -vframes 1 out.yuv

Signed-off-by: Linjie Fu <linjie.fu@intel.com>