### PR TITLE
avfilter/tonemap_vaapi: set va parameters filters and numbers

### DIFF
--- a/libavfilter/vf_tonemap_vaapi.c
+++ b/libavfilter/vf_tonemap_vaapi.c
@@ -296,6 +296,11 @@ static int tonemap_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame
     if (err < 0)
         goto fail;
 
+    if (vpp_ctx->nb_filter_buffers) {
+        params.filters     = &vpp_ctx->filter_buffers[0];
+        params.num_filters = vpp_ctx->nb_filter_buffers;
+    }
+
     err = ff_vaapi_vpp_render_picture(avctx, &params, output_frame);
     if (err < 0)
         goto fail;


### PR DESCRIPTION
This can fill VAProcPipelineParameterBuffer correctly and make the
pipeline works.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>