### PR TITLE
tests/dnn/mathunary: fix the issue of NAN

### DIFF
--- a/libavfilter/dnn/dnn_backend_native_layer_mathunary.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathunary.c
@@ -130,6 +130,10 @@ int dnn_execute_layer_math_unary(DnnOperand *operands, const int32_t *input_oper
         for (int i = 0; i < dims_count; ++i)
             dst[i] = atanh(src[i]);
         return 0;
+    case DMUO_CEIL:
+        for (int i = 0; i < dims_count; ++i)
+            dst[i] = ceil(src[i]);
+        return 0;
     default:
         return -1;
     }

--- a/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
@@ -43,6 +43,7 @@ typedef enum {
     DMUO_ASINH = 10,
     DMUO_ACOSH = 11,
     DMUO_ATANH = 12,
+    DMUO_CEIL = 13,
     DMUO_COUNT
 } DNNMathUnaryOperation;
 

--- a/tests/dnn/dnn-layer-mathunary-test.c
+++ b/tests/dnn/dnn-layer-mathunary-test.c
@@ -56,6 +56,8 @@ static float get_expected(float f, DNNMathUnaryOperation op)
         return acosh(f);
     case DMUO_ATANH:
         return atanh(f);
+    case DMUO_CEIL:
+        return ceil(f);
     default:
         av_assert0(!"not supported yet");
         return 0.f;
@@ -127,6 +129,8 @@ int main(int agrc, char **argv)
     if (test(DMUO_ACOSH))
         return 1;
     if (test(DMUO_ATANH))
+        return 1;
+    if (test(DMUO_CEIL))
         return 1;
     return 0;
 }

--- a/tools/python/convert_from_tensorflow.py
+++ b/tools/python/convert_from_tensorflow.py
@@ -72,7 +72,9 @@ class TFConverter:
         self.conv2d_scopename_inputname_dict = {}
         self.op2code = {'Conv2D':1, 'DepthToSpace':2, 'MirrorPad':3, 'Maximum':4, 'MathBinary':5, 'MathUnary':6}
         self.mathbin2code = {'Sub':0, 'Add':1, 'Mul':2, 'RealDiv':3, 'Minimum':4}
-        self.mathun2code  = {'Abs':0, 'Sin':1, 'Cos':2, 'Tan':3, 'Asin':4, 'Acos':5, 'Atan':6, 'Sinh':7, 'Cosh':8, 'Tanh':9, 'Asinh':10, 'Acosh':11, 'Atanh':12}
+        self.mathun2code  = {'Abs':0, 'Sin':1, 'Cos':2, 'Tan':3, 'Asin':4,
+                'Acos':5, 'Atan':6, 'Sinh':7, 'Cosh':8, 'Tanh':9, 'Asinh':10,
+                'Acosh':11, 'Atanh':12, 'Ceil':13}
         self.mirrorpad_mode = {'CONSTANT':0, 'REFLECT':1, 'SYMMETRIC':2}
         self.name_operand_dict = {}
 

--- a/tools/python/convert_header.py
+++ b/tools/python/convert_header.py
@@ -23,4 +23,4 @@ str = 'FFMPEGDNNNATIVE'
 major = 1
 
 # increase minor when we don't have to re-convert the model file
-minor = 18
+minor = 19


### PR DESCRIPTION
When one of output[i] & expected_output is NAN, the unit test will always pass.

Signed-off-by: Ting Fu <ting.fu@intel.com>