### PR TITLE
swscale/yuv2rgb: consider yuv2rgb30 on big endian environment

### DIFF
--- a/libswscale/input.c
+++ b/libswscale/input.c
@@ -244,11 +244,12 @@ rgb48funcs(bgr, BE, AV_PIX_FMT_BGR48BE)
 #define input_pixel(i) ((origin == AV_PIX_FMT_RGBA ||                      \
                          origin == AV_PIX_FMT_BGRA ||                      \
                          origin == AV_PIX_FMT_ARGB ||                      \
-                         origin == AV_PIX_FMT_ABGR ||                      \
-                         origin == AV_PIX_FMT_X2RGB10)                     \
-                        ? AV_RN32A(&src[(i) * 4])                       \
-                        : (isBE(origin) ? AV_RB16(&src[(i) * 2])        \
-                                        : AV_RL16(&src[(i) * 2])))
+                         origin == AV_PIX_FMT_ABGR)                        \
+                        ? AV_RN32A(&src[(i) * 4])                          \
+                        : ((origin == AV_PIX_FMT_X2RGB10LE)                \
+                           ? AV_RL32(&src[(i) * 4])                        \
+                           : (isBE(origin) ? AV_RB16(&src[(i) * 2])        \
+                              : AV_RL16(&src[(i) * 2]))))
 
 static av_always_inline void rgb16_32ToY_c_template(int16_t *dst,
                                                     const uint8_t *src,

--- a/libswscale/yuv2rgb.c
+++ b/libswscale/yuv2rgb.c
@@ -793,7 +793,8 @@ av_cold int ff_yuv2rgb_c_init_tables(SwsContext *c, const int inv_table[4],
                         c->dstFormat == AV_PIX_FMT_NE(RGB444LE, RGB444BE) ||
                         c->dstFormat == AV_PIX_FMT_NE(BGR565LE, BGR565BE) ||
                         c->dstFormat == AV_PIX_FMT_NE(BGR555LE, BGR555BE) ||
-                        c->dstFormat == AV_PIX_FMT_NE(BGR444LE, BGR444BE);
+                        c->dstFormat == AV_PIX_FMT_NE(BGR444LE, BGR444BE) ||
+                        c->dstFormat == AV_PIX_FMT_NE(X2RGB10LE, X2RGB10BE);
     const int bpp = c->dstFormatBpp;
     uint8_t *y_table;
     uint16_t *y_table16;
@@ -982,6 +983,9 @@ av_cold int ff_yuv2rgb_c_init_tables(SwsContext *c, const int inv_table[4],
             y_table32[i + 2 * table_plane_size] = yval << bbase;
             yb += cy;
         }
+        if (isNotNe)
+	        for (i = 0; i < table_plane_size * 3; i++)
+	            y_table32[i] = av_bswap32(y_table32[i]);
         fill_table(c->table_rV, 4, crv, y_table32 + yoffs);
         fill_table(c->table_gU, 4, cgu, y_table32 + yoffs + table_plane_size);
         fill_table(c->table_bU, 4, cbu, y_table32 + yoffs + 2 * table_plane_size);


### PR DESCRIPTION
This fixed FATE fail report by filter-pixfmts* for x2rgb10le on big
endian environment.