### PR TITLE
lavc/vaapi_encode: Convert P to B-frames if driver doesn't support

### DIFF
--- a/libavcodec/vaapi_encode.h
+++ b/libavcodec/vaapi_encode.h
@@ -329,6 +329,8 @@ typedef struct VAAPIEncodeContext {
     int idr_counter;
     int gop_counter;
     int end_of_stream;
+    // Convert P-frames to B-frames with forward reference only
+    int p_to_b;
 
     // Whether the driver supports ROI at all.
     int             roi_allowed;

--- a/libavcodec/vaapi_encode_h265.c
+++ b/libavcodec/vaapi_encode_h265.c
@@ -895,6 +895,7 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
                                                VAAPIEncodePicture *pic,
                                                VAAPIEncodeSlice *slice)
 {
+    VAAPIEncodeContext                *ctx = avctx->priv_data;
     VAAPIEncodeH265Context           *priv = avctx->priv_data;
     VAAPIEncodeH265Picture           *hpic = pic->priv_data;
     const H265RawSPS                  *sps = &priv->raw_sps;
@@ -916,6 +917,9 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
     sh->slice_segment_address           = slice->block_start;
 
     sh->slice_type = hpic->slice_type;
+
+    if (sh->slice_type == HEVC_SLICE_P && ctx->p_to_b)
+        sh->slice_type = HEVC_SLICE_B;
 
     sh->slice_pic_order_cnt_lsb = hpic->pic_order_cnt &
         (1 << (sps->log2_max_pic_order_cnt_lsb_minus4 + 4)) - 1;
@@ -1075,6 +1079,9 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
         av_assert0(pic->type == PICTURE_TYPE_P ||
                    pic->type == PICTURE_TYPE_B);
         vslice->ref_pic_list0[0] = vpic->reference_frames[0];
+        if (ctx->p_to_b && pic->type == PICTURE_TYPE_P)
+            // Reference for low delay B-frame, L0 == L1
+            vslice->ref_pic_list1[0] = vpic->reference_frames[0];
     }
     if (pic->nb_refs >= 2) {
         // Forward reference for B-frame.


### PR DESCRIPTION
Automatically convert P-frames to B-frames according to the query
results of VAConfigAttribPredictionDirection.

If P-frames is not supported by driver, convert P-frames to B-frames
with 2 same ref_lists(forward-prediction only, low delay B-frames).

If query is not supported with current VAAPI version, convert P to B
by default for low power mode to avoid unexpected errors.

Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>