### PR TITLE
lavc/qsv: fix transcode with interlaced clip

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -521,7 +521,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
             frame->key_frame = !!(out_frame->dec_info.FrameType & MFX_FRAMETYPE_IDR);
 
         /* update the surface properties */
-        if (avctx->pix_fmt == AV_PIX_FMT_QSV)
+        if (frame->format == AV_PIX_FMT_QSV)
             ((mfxFrameSurface1*)frame->data[3])->Info = outsurf->Info;
 
         *got_frame = 1;


### PR DESCRIPTION
1. qsvdec: set output surface info correctly.
2. qsvvpp: set output surface/frame's picture struct according to
input if deinterlace option is not enabled.

This fix will make interlace transcode works:
ffmpeg -init_hw_device qsv=hw:/dev/dri/renderD128 -filter_hw_device  \
hw -hwaccel_output_format qsv -hwaccel qsv -v debug -c:v h264_qsv -i \
1920x1080_interlace.mp4 -vf "vpp_qsv=w=1280:h=720" -c:v h264_qsv     \
-flags +ildct+ilme -preset medium -b:v 10M -y 1280x720_interlace.mp4

Signed-off-by: Fei Wang <fei.w.wang@intel.com>