### PR TITLE
qsv: add ${includedir}/mfx to the search path for old version of libmfx

### DIFF
--- a/configure
+++ b/configure
@@ -1458,6 +1458,14 @@ check_pkg_config(){
         eval add_cflags \$${name}_cflags
 }
 
+append_subdir_to_pkg_includedir(){
+    log append_subdir_to_pkg_includedir "$@"
+    name="$1"
+    subdir="$2"
+    incdir=$($pkg_config --variable=includedir $name)
+    add_cflags -I$incdir/$subdir
+}
+
 test_exec(){
     test_ld "cc" "$@" && { enabled cross_compile || $TMPE >> $logfile 2>&1; }
 }
@@ -6357,10 +6365,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
 # Media SDK or Intel Media Server Studio, these don't come with
 # pkg-config support.  Instead, users should make sure that the build
 # can find the libraries and headers through other means.
-enabled libmfx            && { check_pkg_config libmfx libmfx "mfx/mfxvideo.h" MFXInit ||
-                               { require libmfx "mfx/mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } }
+enabled libmfx            && { check_pkg_config libmfx libmfx "mfxvideo.h" MFXInit ||
+                               { check_pkg_config libmfx libmfx "mfx/mfxvideo.h" MFXInit && append_subdir_to_pkg_includedir libmfx mfx; } ||
+                               { require libmfx "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } }
 if enabled libmfx; then
-   check_cc MFX_CODEC_VP9 "mfx/mfxvp9.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
+   check_cc MFX_CODEC_VP9 "mfxvp9.h mfxstructures.h" "MFX_CODEC_VP9"
 fi
 
 enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load

--- a/fftools/ffmpeg_qsv.c
+++ b/fftools/ffmpeg_qsv.c
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 #include <stdlib.h>
 
 #include "libavutil/dict.h"

--- a/libavcodec/qsv.c
+++ b/libavcodec/qsv.c
@@ -18,9 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <mfx/mfxvideo.h>
-#include <mfx/mfxplugin.h>
-#include <mfx/mfxjpeg.h>
+#include <mfxvideo.h>
+#include <mfxplugin.h>
+#include <mfxjpeg.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -37,7 +37,7 @@
 #include "qsv_internal.h"
 
 #if QSV_VERSION_ATLEAST(1, 12)
-#include "mfx/mfxvp8.h"
+#include "mfxvp8.h"
 #endif
 
 int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)

--- a/libavcodec/qsv.h
+++ b/libavcodec/qsv.h
@@ -21,7 +21,7 @@
 #ifndef AVCODEC_QSV_H
 #define AVCODEC_QSV_H
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/buffer.h"
 

--- a/libavcodec/qsv_internal.h
+++ b/libavcodec/qsv_internal.h
@@ -39,7 +39,7 @@
 #include "libavutil/hwcontext_vaapi.h"
 #endif
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/frame.h"
 

--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/hwcontext.h"

--- a/libavcodec/qsvdec.h
+++ b/libavcodec/qsvdec.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/fifo.h"
 #include "libavutil/frame.h"

--- a/libavcodec/qsvdec_h2645.c
+++ b/libavcodec/qsvdec_h2645.c
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/fifo.h"

--- a/libavcodec/qsvdec_other.c
+++ b/libavcodec/qsvdec_other.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/fifo.h"

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -23,7 +23,7 @@
 
 #include <string.h>
 #include <sys/types.h>
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/hwcontext.h"

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/avutil.h"
 #include "libavutil/fifo.h"

--- a/libavcodec/qsvenc_h264.c
+++ b/libavcodec/qsvenc_h264.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/opt.h"

--- a/libavcodec/qsvenc_hevc.c
+++ b/libavcodec/qsvenc_hevc.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/opt.h"

--- a/libavcodec/qsvenc_jpeg.c
+++ b/libavcodec/qsvenc_jpeg.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/opt.h"

--- a/libavcodec/qsvenc_mpeg2.c
+++ b/libavcodec/qsvenc_mpeg2.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/opt.h"

--- a/libavcodec/qsvenc_vp9.c
+++ b/libavcodec/qsvenc_vp9.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "libavutil/common.h"
 #include "libavutil/opt.h"

--- a/libavfilter/qsvvpp.h
+++ b/libavfilter/qsvvpp.h
@@ -24,7 +24,7 @@
 #ifndef AVFILTER_QSVVPP_H
 #define AVFILTER_QSVVPP_H
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "avfilter.h"
 

--- a/libavfilter/vf_deinterlace_qsv.c
+++ b/libavfilter/vf_deinterlace_qsv.c
@@ -21,7 +21,7 @@
  * deinterlace video filter - QSV
  */
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -21,7 +21,7 @@
  * scale video filter - QSV
  */
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/libavutil/hwcontext_opencl.c
+++ b/libavutil/hwcontext_opencl.c
@@ -47,7 +47,7 @@
 
 #if HAVE_OPENCL_VAAPI_INTEL_MEDIA
 #if CONFIG_LIBMFX
-#include <mfx/mfxstructures.h>
+#include <mfxstructures.h>
 #endif
 #include <va/va.h>
 #include <CL/cl_va_api_media_sharing_intel.h>

--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 #include "config.h"
 

--- a/libavutil/hwcontext_qsv.h
+++ b/libavutil/hwcontext_qsv.h
@@ -19,7 +19,7 @@
 #ifndef AVUTIL_HWCONTEXT_QSV_H
 #define AVUTIL_HWCONTEXT_QSV_H
 
-#include <mfx/mfxvideo.h>
+#include <mfxvideo.h>
 
 /**
  * @file


### PR DESCRIPTION
${inludedir}/mfx has been added to Cflags in libmfx.pc in new versions
of libmfx. We may add ${includedir}/mfx to the search path for old
version of libmfx so that we may inlcude mxfxxx.h instead of
mfx/mfxxxx.h in FFmpeg

If your libmfx comes without pkg-config support, this patch requires a
small change to your environment setting (e.g. adding
/opt/intel/mediasdk/include/mfx instead of /opt/intel/mediasdk/include
to CFLAGS) so that the build can find the headers