### PR TITLE
lavc/qsvdec: allow qsv decoders to use initialized device

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -47,7 +47,8 @@ const AVCodecHWConfigInternal *ff_qsv_hw_configs[] = {
     &(const AVCodecHWConfigInternal) {
         .public = {
             .pix_fmt     = AV_PIX_FMT_QSV,
-            .methods     = AV_CODEC_HW_CONFIG_METHOD_HW_FRAMES_CTX |
+            .methods     = AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX |
+                           AV_CODEC_HW_CONFIG_METHOD_HW_FRAMES_CTX |
                            AV_CODEC_HW_CONFIG_METHOD_AD_HOC,
             .device_type = AV_HWDEVICE_TYPE_QSV,
         },


### PR DESCRIPTION
qsv decoders did not allow to use devices explicitly initialized on
the command line and actually were using default device.

Example:
ffmpeg -init_hw_device vaapi=va:/dev/dri/renderD129 -init_hw_device qsv=hw@va \
  -c:v h264_qsv -i input.h264 -c:v hevc_qsv -y output.h264

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>