### PR TITLE
FATE/dnn: only run unit test when CONFIG_DNN enabled

### DIFF
--- a/tests/fate/dnn.mak
+++ b/tests/fate/dnn.mak
@@ -33,6 +33,6 @@ fate-dnn-layer-avgpool: $(DNNTESTSDIR)/dnn-layer-avgpool-test$(EXESUF)
 fate-dnn-layer-avgpool: CMD = run $(DNNTESTSDIR)/dnn-layer-avgpool-test$(EXESUF)
 fate-dnn-layer-avgpool: CMP = null
 
-FATE-yes += $(FATE_DNN)
+FATE-$(CONFIG_DNN) += $(FATE_DNN)
 
 fate-dnn: $(FATE_DNN)


### PR DESCRIPTION
Signed-off-by: Peter Ross <pross@xvid.org>