### PR TITLE
ffmpeg_qsv: repect hwaccel_output_format setting

### DIFF
--- a/fftools/ffmpeg_opt.c
+++ b/fftools/ffmpeg_opt.c
@@ -884,6 +884,12 @@ static void add_input_streams(OptionsContext *o, AVFormatContext *ic)
                     "with old commandlines. This behaviour is DEPRECATED and will be removed "
                     "in the future. Please explicitly set \"-hwaccel_output_format cuda\".\n");
                 ist->hwaccel_output_format = AV_PIX_FMT_CUDA;
+            } else if (!hwaccel_output_format && hwaccel && !strcmp(hwaccel, "qsv")) {
+                av_log(NULL, AV_LOG_WARNING,
+                    "WARNING: defaulting hwaccel_output_format to qsv for compatibility "
+                    "with old commandlines. This behaviour is DEPRECATED and will be removed "
+                    "in the future. Please explicitly set \"-hwaccel_output_format qsv\".\n");
+                ist->hwaccel_output_format = AV_PIX_FMT_QSV;
             } else if (hwaccel_output_format) {
                 ist->hwaccel_output_format = av_get_pix_fmt(hwaccel_output_format);
                 if (ist->hwaccel_output_format == AV_PIX_FMT_NONE) {

--- a/fftools/ffmpeg_qsv.c
+++ b/fftools/ffmpeg_qsv.c
@@ -82,6 +82,8 @@ int qsv_init(AVCodecContext *s)
             return ret;
     }
 
+    hwaccel_decode_init(s);
+
     av_buffer_unref(&ist->hw_frames_ctx);
     ist->hw_frames_ctx = av_hwframe_ctx_alloc(hw_device_ctx);
     if (!ist->hw_frames_ctx)


### PR DESCRIPTION
Without thix change, the output pixel format from qsv decoder is always
qsv regardless of the hwaccel_output_format setting, user will get
rrors when FFmpeg inserts an auto filter to convert the decoder output
to the specified format.

Fox example:

ffmpeg -loglevel verbose -hwaccel qsv -c:v h264_qsv
-hwaccel_output_format yuv420p -i input.h264
-pix_fmt rgb24 -f null -

......
[graph 0 input from stream 0:0 @ 0x55c057c8f050] w:1280 h:720 pixfmt:qsv
tb:1/1001 fr:30000/1001 sar:1/1
[auto_scaler_0 @ 0x55c057c90d20] w:iw h:ih flags:'bicubic' interl:0
[format @ 0x55c057c8f990] auto-inserting filter 'auto_scaler_0' between
the filter 'Parsed_null_0' and the filter 'format'
Impossible to convert between the formats supported by the filter
'Parsed_null_0' and the filter 'auto_scaler_0'
Error reinitializing filters!
Failed to inject frame into filter network: Function not implemented
Error while processing the decoded data for stream #0: