### PR TITLE
lavf/utils: return NULL if no proper decoder probed

### DIFF
--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -226,6 +226,7 @@ static const AVCodec *find_probe_decoder(AVFormatContext *s, const AVStream *st,
                 return probe_codec;
             }
         }
+        return NULL;
     }
 
     return codec;


### PR DESCRIPTION
If all candiate codecs has capability of AV_CODEC_CAP_AVOID_PROBING,
return NULL.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>