### PR TITLE
Pr hevc scc parsing

### DIFF
--- a/libavcodec/avcodec.h
+++ b/libavcodec/avcodec.h
@@ -1948,6 +1948,7 @@ typedef struct AVCodecContext {
 #define FF_PROFILE_HEVC_MAIN_10                     2
 #define FF_PROFILE_HEVC_MAIN_STILL_PICTURE          3
 #define FF_PROFILE_HEVC_REXT                        4
+#define FF_PROFILE_HEVC_SCC                         9
 
 #define FF_PROFILE_AV1_MAIN                         0
 #define FF_PROFILE_AV1_HIGH                         1

--- a/libavcodec/hevc.h
+++ b/libavcodec/hevc.h
@@ -154,6 +154,9 @@ enum {
     // get near that, though, so set a lower limit here with the maximum
     // possible value for 4K video (at most 135 16x16 Ctb rows).
     HEVC_MAX_ENTRY_POINT_OFFSETS = HEVC_MAX_TILE_COLUMNS * 135,
+
+    // A.3.7: Screen content coding extensions
+    HEVC_MAX_PALETTE_PREDICTOR_SIZE = 128,
 };
 
 

--- a/libavcodec/hevc_parser.c
+++ b/libavcodec/hevc_parser.c
@@ -75,7 +75,7 @@ static int hevc_parse_slice_header(AVCodecParserContext *s, H2645NAL *nal,
 
     pps_id = get_ue_golomb(gb);
     if (pps_id >= HEVC_MAX_PPS_COUNT || !ps->pps_list[pps_id]) {
-        av_log(avctx, AV_LOG_ERROR, "PPS id out of range: %d\n", pps_id);
+        av_log(avctx, AV_LOG_ERROR, "PPS id out of range or empty pps_list[%d]: %d\n", pps_id, pps_id);
         return AVERROR_INVALIDDATA;
     }
     ps->pps = (HEVCPPS*)ps->pps_list[pps_id]->data;

--- a/libavcodec/hevc_ps.c
+++ b/libavcodec/hevc_ps.c
@@ -281,6 +281,8 @@ static int decode_profile_tier_level(GetBitContext *gb, AVCodecContext *avctx,
         av_log(avctx, AV_LOG_DEBUG, "Main Still Picture profile bitstream\n");
     else if (ptl->profile_idc == FF_PROFILE_HEVC_REXT)
         av_log(avctx, AV_LOG_DEBUG, "Range Extension profile bitstream\n");
+    else if (ptl->profile_idc == FF_PROFILE_HEVC_SCC)
+        av_log(avctx, AV_LOG_DEBUG, "Screen Content Coding Extension profile bitstream\n");
     else
         av_log(avctx, AV_LOG_WARNING, "Unknown HEVC profile: %d\n", ptl->profile_idc);
 

--- a/libavcodec/hevc_ps.c
+++ b/libavcodec/hevc_ps.c
@@ -909,7 +909,7 @@ int ff_hevc_parse_sps(HEVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
     HEVCWindow *ow;
     int ret = 0;
     int log2_diff_max_min_transform_block_size;
-    int bit_depth_chroma, start, vui_present, sublayer_ordering_info;
+    int bit_depth_chroma, start, vui_present, sublayer_ordering_info, num_comps;
     int i;
 
     // Coded parameters
@@ -1130,8 +1130,20 @@ int ff_hevc_parse_sps(HEVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
         decode_vui(gb, avctx, apply_defdispwin, sps);
 
     if (get_bits1(gb)) { // sps_extension_flag
-        sps->sps_range_extension_flag = get_bits1(gb);
-        skip_bits(gb, 7); //sps_extension_7bits = get_bits(gb, 7);
+        sps->sps_range_extension_flag      = get_bits1(gb);
+
+        /* To keep consistency with the workaround for hevc-conformance-PS_A_VIDYO_3
+         * in PPS, here ignore sps_multilayer_extension_flag, sps_3d_extension_flag
+         * and sps_scc_extension_flag for non-SCC streams too. Note multilayer_extension
+         * or 3d_extension is not implemented in FFmpeg */
+        if (sps->ptl.general_ptl.profile_idc == FF_PROFILE_HEVC_SCC) {
+            sps->sps_multilayer_extension_flag = get_bits1(gb);
+            sps->sps_3d_extension_flag         = get_bits1(gb);
+            sps->sps_scc_extension_flag        = get_bits1(gb);
+            skip_bits(gb, 4); //sps_extension_4bits = get_bits(gb, 4);
+        } else
+            skip_bits(gb, 7);
+
         if (sps->sps_range_extension_flag) {
             sps->transform_skip_rotation_enabled_flag = get_bits1(gb);
             sps->transform_skip_context_enabled_flag  = get_bits1(gb);
@@ -1156,6 +1168,32 @@ int ff_hevc_parse_sps(HEVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
             if (sps->cabac_bypass_alignment_enabled_flag)
                 av_log(avctx, AV_LOG_WARNING,
                    "cabac_bypass_alignment_enabled_flag not yet implemented\n");
+        }
+        if (sps->sps_multilayer_extension_flag || sps->sps_3d_extension_flag) {
+            av_log(avctx, AV_LOG_ERROR,
+                   "multilayer_extension or 3d_extension not yet implemented\n");
+            return AVERROR_PATCHWELCOME;
+        }
+
+        if (sps->sps_scc_extension_flag) {
+            sps->sps_curr_pic_ref_enabled_flag = get_bits1(gb);
+            sps->palette_mode_enabled_flag     = get_bits1(gb);
+            if (sps->palette_mode_enabled_flag) {
+                sps->palette_max_size = get_ue_golomb_long(gb);
+                sps->delta_palette_max_predictor_size = get_ue_golomb_long(gb);
+                sps->sps_palette_predictor_initializers_present_flag = get_bits1(gb);
+
+                if (sps->sps_palette_predictor_initializers_present_flag) {
+                    sps->sps_num_palette_predictor_initializers_minus1 = get_ue_golomb_long(gb);
+                    num_comps = !sps->chroma_format_idc ? 1 : 3;
+                    for (int comp = 0; comp < num_comps; comp++)
+                        for (i = 0; i <= sps->sps_num_palette_predictor_initializers_minus1; i++)
+                            sps->sps_palette_predictor_initializer[comp][i] =
+                                    get_bits(gb, !comp ? sps->bit_depth : sps->bit_depth_chroma);
+                }
+            }
+            sps->motion_vector_resolution_control_idc   = get_bits(gb, 2);
+            sps->intra_boundary_filtering_disabled_flag = get_bits1(gb);
         }
     }
     if (apply_defdispwin) {

--- a/libavcodec/hevc_ps.c
+++ b/libavcodec/hevc_ps.c
@@ -1400,6 +1400,48 @@ static int pps_range_extensions(GetBitContext *gb, AVCodecContext *avctx,
     return(0);
 }
 
+static int pps_scc_extension(GetBitContext *gb, AVCodecContext *avctx,
+                             HEVCPPS *pps, HEVCSPS *sps)
+{
+    int num_comps;
+    int i, ret;
+
+    pps->pps_curr_pic_ref_enabled_flag = get_bits1(gb);
+    if (pps->residual_adaptive_colour_transform_enabled_flag = get_bits1(gb)) {
+        pps->pps_slice_act_qp_offsets_present_flag = get_bits1(gb);
+        pps->pps_act_y_qp_offset  = get_se_golomb_long(gb) - 5;
+        pps->pps_act_cb_qp_offset = get_se_golomb_long(gb) - 5;
+        pps->pps_act_cr_qp_offset = get_se_golomb_long(gb) - 3;
+
+#define CHECK_QP_OFFSET(name) (pps->pps_act_ ## name ## _qp_offset < -12 || \
+                               pps->pps_act_ ## name ## _qp_offset > 12)
+        ret = CHECK_QP_OFFSET(y) || CHECK_QP_OFFSET(cb) || CHECK_QP_OFFSET(cr);
+#undef CHECK_QP_OFFSET
+        if (ret) {
+            av_log(avctx, AV_LOG_ERROR,
+                   "PpsActQpOffsetY/Cb/Cr shall be in the range of [-12, 12].\n");
+            return AVERROR_INVALIDDATA;
+        }
+    }
+
+    if (pps->pps_palette_predictor_initializers_present_flag = get_bits1(gb)) {
+        if ((pps->pps_num_palette_predictor_initializers = get_ue_golomb_long(gb)) > 0) {
+            pps->monochrome_palette_flag = get_bits1(gb);
+            pps->luma_bit_depth_entry_minus8 = get_ue_golomb_long(gb);
+            if (!pps->monochrome_palette_flag)
+                pps->chroma_bit_depth_entry_minus8 = get_ue_golomb_long(gb);
+            num_comps = pps->monochrome_palette_flag ? 1 : 3;
+            for (int comp = 0; comp < num_comps; comp++)
+                for (i = 0; i < pps->pps_num_palette_predictor_initializers; i++)
+                    pps->pps_palette_predictor_initializer[comp][i] =
+                        get_bits(gb, 8 + (!comp ? pps->luma_bit_depth_entry_minus8 :
+                                          pps->chroma_bit_depth_entry_minus8));
+        }
+    }
+
+    return 0;
+}
+
 static inline int setup_pps(AVCodecContext *avctx, GetBitContext *gb,
                             HEVCPPS *pps, HEVCSPS *sps)
 {
@@ -1753,9 +1795,35 @@ int ff_hevc_decode_nal_pps(GetBitContext *gb, AVCodecContext *avctx,
 
     if (get_bits1(gb)) { // pps_extension_present_flag
         pps->pps_range_extensions_flag = get_bits1(gb);
-        skip_bits(gb, 7); // pps_extension_7bits
+
+        /* hevc-conformance-PS_A_VIDYO_3 in fate has pps_multilayer_extension_flag (1),
+         * pps_3d_extension_flag (1) and pps_scc_extension_flag (1) but has the wrong
+         * data for pps_multilayer_extension(), pps_3d_extension(), and pps_scc_extension().
+         * To avoid regression for hevc-conformance-PS_A_VIDYO_3, here check
+         * pps_multilayer_extension_flag, pps_3d_extension_flag and pps_scc_extension_flag
+         * only for SCC streams */
+        if (sps->ptl.general_ptl.profile_idc == FF_PROFILE_HEVC_SCC) {
+            pps->pps_multilayer_extension_flag = get_bits1(gb);
+            pps->pps_3d_extension_flag         = get_bits1(gb);
+            pps->pps_scc_extension_flag        = get_bits1(gb);
+            skip_bits(gb, 4); // pps_extension_4bits
+        } else
+            skip_bits(gb, 7);
+
         if (sps->ptl.general_ptl.profile_idc == FF_PROFILE_HEVC_REXT && pps->pps_range_extensions_flag) {
             if ((ret = pps_range_extensions(gb, avctx, pps, sps)) < 0)
+                goto err;
+        }
+
+        if (pps->pps_multilayer_extension_flag || pps->pps_3d_extension_flag) {
+            av_log(avctx, AV_LOG_ERROR,
+                   "multilayer_extension or 3d_extension not yet implemented\n");
+            ret = AVERROR_PATCHWELCOME;
+            goto err;
+        }
+
+        if (pps->pps_scc_extension_flag) {
+            if ((ret = pps_scc_extension(gb, avctx, pps, sps)) < 0)
                 goto err;
         }
     }

--- a/libavcodec/hevc_ps.h
+++ b/libavcodec/hevc_ps.h
@@ -223,6 +223,21 @@ typedef struct HEVCSPS {
     int persistent_rice_adaptation_enabled_flag;
     int cabac_bypass_alignment_enabled_flag;
 
+    // Not yet implemented
+    int sps_multilayer_extension_flag;
+    int sps_3d_extension_flag;
+
+    int sps_scc_extension_flag;
+    int sps_curr_pic_ref_enabled_flag;
+    int palette_mode_enabled_flag;
+    int palette_max_size;
+    int delta_palette_max_predictor_size;
+    int sps_palette_predictor_initializers_present_flag;
+    int sps_num_palette_predictor_initializers_minus1;
+    int sps_palette_predictor_initializer[3][HEVC_MAX_PALETTE_PREDICTOR_SIZE];
+    int motion_vector_resolution_control_idc;
+    int intra_boundary_filtering_disabled_flag;
+
     ///< coded frame dimension in various units
     int width;
     int height;

--- a/libavcodec/hevc_ps.h
+++ b/libavcodec/hevc_ps.h
@@ -312,6 +312,9 @@ typedef struct HEVCPPS {
     uint8_t slice_header_extension_present_flag;
     uint8_t log2_max_transform_skip_block_size;
     uint8_t pps_range_extensions_flag;
+    uint8_t pps_multilayer_extension_flag;
+    uint8_t pps_3d_extension_flag;
+    uint8_t pps_scc_extension_flag;
     uint8_t cross_component_prediction_enabled_flag;
     uint8_t chroma_qp_offset_list_enabled_flag;
     uint8_t diff_cu_chroma_qp_offset_depth;
@@ -320,6 +323,20 @@ typedef struct HEVCPPS {
     int8_t  cr_qp_offset_list[6];
     uint8_t log2_sao_offset_scale_luma;
     uint8_t log2_sao_offset_scale_chroma;
+
+    // SCC extension parameters
+    uint8_t pps_curr_pic_ref_enabled_flag;
+    uint8_t residual_adaptive_colour_transform_enabled_flag;
+    uint8_t pps_slice_act_qp_offsets_present_flag;
+    int8_t  pps_act_y_qp_offset;  // _plus5
+    int8_t  pps_act_cb_qp_offset; // _plus5
+    int8_t  pps_act_cr_qp_offset; // _plus3
+    uint8_t pps_palette_predictor_initializers_present_flag;
+    uint8_t pps_num_palette_predictor_initializers;
+    uint8_t monochrome_palette_flag;
+    uint8_t luma_bit_depth_entry_minus8;
+    uint8_t chroma_bit_depth_entry_minus8;
+    uint8_t pps_palette_predictor_initializer[3][HEVC_MAX_PALETTE_PREDICTOR_SIZE];
 
     // Inferred parameters
     unsigned int *column_width;  ///< ColumnWidth

--- a/libavcodec/hevc_refs.c
+++ b/libavcodec/hevc_refs.c
@@ -301,7 +301,7 @@ int ff_hevc_slice_rpl(HEVCContext *s)
         return ret;
 
     if (!(s->rps[ST_CURR_BEF].nb_refs + s->rps[ST_CURR_AFT].nb_refs +
-          s->rps[LT_CURR].nb_refs)) {
+          s->rps[LT_CURR].nb_refs) && !s->ps.pps->pps_curr_pic_ref_enabled_flag) {
         av_log(s->avctx, AV_LOG_ERROR, "Zero refs in the frame RPS.\n");
         return AVERROR_INVALIDDATA;
     }
@@ -328,6 +328,12 @@ int ff_hevc_slice_rpl(HEVCContext *s)
                     rpl_tmp.nb_refs++;
                 }
             }
+            // Construct RefPicList0, RefPicList1 (8-8, 8-10)
+            if (s->ps.pps->pps_curr_pic_ref_enabled_flag) {
+                rpl_tmp.ref[rpl_tmp.nb_refs]            = s->ref;
+                rpl_tmp.isLongTerm[rpl_tmp.nb_refs]     = 1;
+                rpl_tmp.nb_refs++;
+            }
         }
 
         /* reorder the references if necessary */
@@ -348,6 +354,12 @@ int ff_hevc_slice_rpl(HEVCContext *s)
         } else {
             memcpy(rpl, &rpl_tmp, sizeof(*rpl));
             rpl->nb_refs = FFMIN(rpl->nb_refs, sh->nb_refs[list_idx]);
+        }
+
+        // 8-9
+        if (s->ps.pps->pps_curr_pic_ref_enabled_flag && sh->slice_type == HEVC_SLICE_P &&
+            !sh->rpl_modification_flag[list_idx] && rpl_tmp.nb_refs > sh->nb_refs[L0]) {
+            rpl->ref[sh->nb_refs[L0]] = s->ref;
         }
 
         if (sh->collocated_list == list_idx &&
@@ -423,7 +435,8 @@ static int add_candidate_ref(HEVCContext *s, RefPicList *list,
 {
     HEVCFrame *ref = find_ref_idx(s, poc, use_msb);
 
-    if (ref == s->ref || list->nb_refs >= HEVC_MAX_REFS)
+    if ((ref == s->ref && !s->ps.pps->pps_curr_pic_ref_enabled_flag) ||
+        list->nb_refs >= HEVC_MAX_REFS)
         return AVERROR_INVALIDDATA;
 
     if (!ref) {
@@ -492,6 +505,12 @@ int ff_hevc_frame_rps(HEVCContext *s)
             goto fail;
     }
 
+    if (s->ps.pps->pps_curr_pic_ref_enabled_flag) {
+        ret = add_candidate_ref(s, &rps[LT_FOLL], s->poc, HEVC_FRAME_FLAG_LONG_REF, 1);
+        if (ret < 0)
+            goto fail;
+    }
+
 fail:
     /* release any frames that are now unused */
     for (i = 0; i < FF_ARRAY_ELEMS(s->DPB); i++)
@@ -518,5 +537,9 @@ int ff_hevc_frame_nb_refs(const HEVCContext *s)
         for (i = 0; i < long_rps->nb_refs; i++)
             ret += !!long_rps->used[i];
     }
+
+    if (s->ps.pps->pps_curr_pic_ref_enabled_flag)
+        ret++;
+
     return ret;
 }

--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -554,7 +554,7 @@ static int hls_slice_header(HEVCContext *s)
 
     sh->pps_id = get_ue_golomb_long(gb);
     if (sh->pps_id >= HEVC_MAX_PPS_COUNT || !s->ps.pps_list[sh->pps_id]) {
-        av_log(s->avctx, AV_LOG_ERROR, "PPS id out of range: %d\n", sh->pps_id);
+        av_log(s->avctx, AV_LOG_ERROR, "PPS id out of range or empty pps_list[%d]: %d\n", sh->pps_id, sh->pps_id);
         return AVERROR_INVALIDDATA;
     }
     if (!sh->first_slice_in_pic_flag &&

--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -808,6 +808,14 @@ static int hls_slice_header(HEVCContext *s)
                        sh->max_num_merge_cand);
                 return AVERROR_INVALIDDATA;
             }
+
+            // Syntax in 7.3.6.1
+            if (s->ps.sps->motion_vector_resolution_control_idc == 2)
+                sh->use_integer_mv_flag = get_bits1(gb);
+            else
+                // Inferred to be equal to motion_vector_resolution_control_idc if not present
+                sh->use_integer_mv_flag = s->ps.sps->motion_vector_resolution_control_idc;
+
         }
 
         sh->slice_qp_delta = get_se_golomb(gb);

--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -825,6 +825,12 @@ static int hls_slice_header(HEVCContext *s)
             sh->slice_cr_qp_offset = 0;
         }
 
+        if (s->ps.pps->pps_slice_act_qp_offsets_present_flag) {
+            sh->slice_act_y_qp_offset  = get_se_golomb(gb);
+            sh->slice_act_cb_qp_offset = get_se_golomb(gb);
+            sh->slice_act_cr_qp_offset = get_se_golomb(gb);
+        }
+
         if (s->ps.pps->chroma_qp_offset_list_enabled_flag)
             sh->cu_chroma_qp_offset_enabled_flag = get_bits1(gb);
         else

--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -637,7 +637,8 @@ static int hls_slice_header(HEVCContext *s)
                    sh->slice_type);
             return AVERROR_INVALIDDATA;
         }
-        if (IS_IRAP(s) && sh->slice_type != HEVC_SLICE_I) {
+        if (IS_IRAP(s) && sh->slice_type != HEVC_SLICE_I &&
+            s->ps.sps->ptl.general_ptl.profile_idc != FF_PROFILE_HEVC_SCC) {
             av_log(s->avctx, AV_LOG_ERROR, "Inter slices in an IRAP frame.\n");
             return AVERROR_INVALIDDATA;
         }
@@ -751,6 +752,9 @@ static int hls_slice_header(HEVCContext *s)
             nb_refs = ff_hevc_frame_nb_refs(s);
             if (!nb_refs) {
                 av_log(s->avctx, AV_LOG_ERROR, "Zero refs for a frame with P or B slices.\n");
+                return AVERROR_INVALIDDATA;
+            } else if (s->ps.pps->pps_curr_pic_ref_enabled_flag) {
+                av_log(s->avctx, AV_LOG_ERROR, "Self refs for a frame is not supprted yet.\n");
                 return AVERROR_INVALIDDATA;
             }
 

--- a/libavcodec/hevcdec.h
+++ b/libavcodec/hevcdec.h
@@ -292,6 +292,10 @@ typedef struct SliceHeader {
     int slice_cb_qp_offset;
     int slice_cr_qp_offset;
 
+    int slice_act_y_qp_offset;
+    int slice_act_cb_qp_offset;
+    int slice_act_cr_qp_offset;
+
     uint8_t cu_chroma_qp_offset_enabled_flag;
 
     int beta_offset;    ///< beta_offset_div2 * 2

--- a/libavcodec/hevcdec.h
+++ b/libavcodec/hevcdec.h
@@ -301,7 +301,7 @@ typedef struct SliceHeader {
     int beta_offset;    ///< beta_offset_div2 * 2
     int tc_offset;      ///< tc_offset_div2 * 2
 
-    unsigned int max_num_merge_cand; ///< 5 - 5_minus_max_num_merge_cand
+    uint8_t max_num_merge_cand; ///< 5 - 5_minus_max_num_merge_cand
     uint8_t use_integer_mv_flag;
 
     unsigned *entry_point_offset;

--- a/libavcodec/hevcdec.h
+++ b/libavcodec/hevcdec.h
@@ -302,6 +302,7 @@ typedef struct SliceHeader {
     int tc_offset;      ///< tc_offset_div2 * 2
 
     unsigned int max_num_merge_cand; ///< 5 - 5_minus_max_num_merge_cand
+    uint8_t use_integer_mv_flag;
 
     unsigned *entry_point_offset;
     int * offset;

--- a/libavcodec/profiles.c
+++ b/libavcodec/profiles.c
@@ -79,6 +79,7 @@ const AVProfile ff_hevc_profiles[] = {
     { FF_PROFILE_HEVC_MAIN_10,              "Main 10"             },
     { FF_PROFILE_HEVC_MAIN_STILL_PICTURE,   "Main Still Picture"  },
     { FF_PROFILE_HEVC_REXT,                 "Rext"                },
+    { FF_PROFILE_HEVC_SCC,                  "Scc"                 },
     { FF_PROFILE_UNKNOWN },
 };
 


### PR DESCRIPTION
[V3]:
- Fix the hang issue
- Add logs for user to prompt  that self referencing is not supported by native decoder.
- Overread PPS is weird, and lacks of bitstream analyzer to check.

Details in :
https://docs.google.com/document/d/1xKbqGUtfHPAHnAo0rTSB_26Z7r2G2jUKGh5dbTHjigI/edit?usp=sharing