### PR TITLE
dnn: fix redefining typedefs and also refine naming with correct prefix

### DIFF
--- a/libavfilter/dnn/dnn_backend_openvino.c
+++ b/libavfilter/dnn/dnn_backend_openvino.c
@@ -53,8 +53,8 @@ typedef struct OVModel{
     ie_infer_request_t *infer_request;
 
     /* for async execution */
-    safe_queue *request_queue;  // holds RequestItem
-    queue *task_queue;          // holds TaskItem
+    FFSafeQueue *request_queue;   // holds RequestItem
+    FFQueue *task_queue;          // holds TaskItem
 } OVModel;
 
 typedef struct TaskItem {
@@ -208,7 +208,7 @@ static void infer_completion_callback(void *args)
 
     if (task->async) {
         request->task = NULL;
-        safe_queue_push_back(task->ov_model->request_queue, request);
+        ff_safe_queue_push_back(task->ov_model->request_queue, request);
     }
 
     task->done = 1;
@@ -417,7 +417,7 @@ DNNModel *ff_dnn_load_model_ov(const char *model_filename, const char *options, 
         ctx->options.nireq = av_cpu_count() / 2 + 1;
     }
 
-    ov_model->request_queue = safe_queue_create();
+    ov_model->request_queue = ff_safe_queue_create();
     if (!ov_model->request_queue) {
         goto err;
     }
@@ -436,10 +436,10 @@ DNNModel *ff_dnn_load_model_ov(const char *model_filename, const char *options, 
         item->infer_request = request;
         item->callback.completeCallBackFunc = infer_completion_callback;
         item->callback.args = item;
-        safe_queue_push_back(ov_model->request_queue, item);
+        ff_safe_queue_push_back(ov_model->request_queue, item);
     }
 
-    ov_model->task_queue = queue_create();
+    ov_model->task_queue = ff_queue_create();
     if (!ov_model->task_queue) {
         goto err;
     }
@@ -527,9 +527,9 @@ DNNReturnType ff_dnn_execute_model_async_ov(const DNNModel *model, const char *i
     task->output_name = output_names[0];
     task->out_frame = out_frame;
     task->ov_model = ov_model;
-    queue_push_back(ov_model->task_queue, task);
+    ff_queue_push_back(ov_model->task_queue, task);
 
-    request = safe_queue_pop_front(ov_model->request_queue);
+    request = ff_safe_queue_pop_front(ov_model->request_queue);
     if (!request) {
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
         return DNN_ERROR;
@@ -541,7 +541,7 @@ DNNReturnType ff_dnn_execute_model_async_ov(const DNNModel *model, const char *i
 DNNAsyncStatusType ff_dnn_get_async_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out)
 {
     OVModel *ov_model = (OVModel *)model->model;
-    TaskItem *task = queue_peek_front(ov_model->task_queue);
+    TaskItem *task = ff_queue_peek_front(ov_model->task_queue);
 
     if (!task) {
         return DAST_EMPTY_QUEUE;
@@ -553,7 +553,7 @@ DNNAsyncStatusType ff_dnn_get_async_result_ov(const DNNModel *model, AVFrame **i
 
     *in = task->in_frame;
     *out = task->out_frame;
-    queue_pop_front(ov_model->task_queue);
+    ff_queue_pop_front(ov_model->task_queue);
     av_freep(&task);
 
     return DAST_SUCCESS;
@@ -563,20 +563,20 @@ void ff_dnn_free_model_ov(DNNModel **model)
 {
     if (*model){
         OVModel *ov_model = (OVModel *)(*model)->model;
-        while (safe_queue_size(ov_model->request_queue) != 0) {
-            RequestItem *item = safe_queue_pop_front(ov_model->request_queue);
+        while (ff_safe_queue_size(ov_model->request_queue) != 0) {
+            RequestItem *item = ff_safe_queue_pop_front(ov_model->request_queue);
             if (item && item->infer_request) {
                 ie_infer_request_free(&item->infer_request);
             }
             av_freep(&item);
         }
-        safe_queue_destroy(ov_model->request_queue);
+        ff_safe_queue_destroy(ov_model->request_queue);
 
-        while (queue_size(ov_model->task_queue) != 0) {
-            TaskItem *item = queue_pop_front(ov_model->task_queue);
+        while (ff_queue_size(ov_model->task_queue) != 0) {
+            TaskItem *item = ff_queue_pop_front(ov_model->task_queue);
             av_freep(&item);
         }
-        queue_destroy(ov_model->task_queue);
+        ff_queue_destroy(ov_model->task_queue);
 
         if (ov_model->infer_request)
             ie_infer_request_free(&ov_model->infer_request);

--- a/libavfilter/dnn/queue.c
+++ b/libavfilter/dnn/queue.c
@@ -23,31 +23,31 @@
 #include "libavutil/mem.h"
 #include "libavutil/avassert.h"
 
-typedef struct _queue_entry queue_entry;
+typedef struct FFQueueEntry FFQueueEntry;
 
-typedef struct _queue {
-    queue_entry *head;
-    queue_entry *tail;
-    size_t length;
-}queue;
-
-typedef struct _queue_entry {
+struct FFQueueEntry {
     void *value;
-    queue_entry *prev;
-    queue_entry *next;
-} queue_entry;
+    FFQueueEntry *prev;
+    FFQueueEntry *next;
+};
 
-static inline queue_entry *create_entry(void *val)
+struct FFQueue {
+    FFQueueEntry *head;
+    FFQueueEntry *tail;
+    size_t length;
+};
+
+static inline FFQueueEntry *create_entry(void *val)
 {
-    queue_entry *entry = av_malloc(sizeof(*entry));
+    FFQueueEntry *entry = av_malloc(sizeof(*entry));
     av_assert0(entry != NULL);
     entry->value = val;
     return entry;
 }
 
-queue* queue_create(void)
+FFQueue* ff_queue_create(void)
 {
-    queue *q = av_malloc(sizeof(*q));
+    FFQueue *q = av_malloc(sizeof(*q));
     if (!q)
         return NULL;
 
@@ -62,15 +62,15 @@ queue* queue_create(void)
     return q;
 }
 
-void queue_destroy(queue *q)
+void ff_queue_destroy(FFQueue *q)
 {
-    queue_entry *entry;
+    FFQueueEntry *entry;
     if (!q)
         return;
 
     entry = q->head;
     while (entry != NULL) {
-        queue_entry *temp = entry;
+        FFQueueEntry *temp = entry;
         entry = entry->next;
         av_freep(&temp);
     }
@@ -78,12 +78,12 @@ void queue_destroy(queue *q)
     av_freep(&q);
 }
 
-size_t queue_size(queue *q)
+size_t ff_queue_size(FFQueue *q)
 {
      return q ? q->length : 0;
 }
 
-void *queue_peek_front(queue *q)
+void *ff_queue_peek_front(FFQueue *q)
 {
     if (!q || q->length == 0)
         return NULL;
@@ -91,7 +91,7 @@ void *queue_peek_front(queue *q)
     return q->head->next->value;
 }
 
-void *queue_peek_back(queue *q)
+void *ff_queue_peek_back(FFQueue *q)
 {
     if (!q || q->length == 0)
         return NULL;
@@ -99,10 +99,10 @@ void *queue_peek_back(queue *q)
     return q->tail->prev->value;
 }
 
-void queue_push_front(queue *q, void *v)
+void ff_queue_push_front(FFQueue *q, void *v)
 {
-    queue_entry *new_entry;
-    queue_entry *original_next;
+    FFQueueEntry *new_entry;
+    FFQueueEntry *original_next;
     if (!q)
         return;
 
@@ -116,10 +116,10 @@ void queue_push_front(queue *q, void *v)
     q->length++;
 }
 
-void queue_push_back(queue *q, void *v)
+void ff_queue_push_back(FFQueue *q, void *v)
 {
-    queue_entry *new_entry;
-    queue_entry *original_prev;
+    FFQueueEntry *new_entry;
+    FFQueueEntry *original_prev;
     if (!q)
         return;
 
@@ -133,10 +133,10 @@ void queue_push_back(queue *q, void *v)
     q->length++;
 }
 
-void *queue_pop_front(queue *q)
+void *ff_queue_pop_front(FFQueue *q)
 {
-    queue_entry *front;
-    queue_entry *new_head_next;
+    FFQueueEntry *front;
+    FFQueueEntry *new_head_next;
     void *ret;
 
     if (!q || q->length == 0)
@@ -154,10 +154,10 @@ void *queue_pop_front(queue *q)
     return ret;
 }
 
-void *queue_pop_back(queue *q)
+void *ff_queue_pop_back(FFQueue *q)
 {
-    queue_entry *back;
-    queue_entry *new_tail_prev;
+    FFQueueEntry *back;
+    FFQueueEntry *new_tail_prev;
     void *ret;
 
     if (!q || q->length == 0)

--- a/libavfilter/dnn/queue.h
+++ b/libavfilter/dnn/queue.h
@@ -22,20 +22,20 @@
 #ifndef AVFILTER_DNN_QUEUE_H
 #define AVFILTER_DNN_QUEUE_H
 
-typedef struct _queue queue;
+typedef struct FFQueue FFQueue;
 
-queue *queue_create(void);
-void queue_destroy(queue *q);
+FFQueue *ff_queue_create(void);
+void ff_queue_destroy(FFQueue *q);
 
-size_t queue_size(queue *q);
+size_t ff_queue_size(FFQueue *q);
 
-void *queue_peek_front(queue *q);
-void *queue_peek_back(queue *q);
+void *ff_queue_peek_front(FFQueue *q);
+void *ff_queue_peek_back(FFQueue *q);
 
-void queue_push_front(queue *q, void *v);
-void queue_push_back(queue *q, void *v);
+void ff_queue_push_front(FFQueue *q, void *v);
+void ff_queue_push_back(FFQueue *q, void *v);
 
-void *queue_pop_front(queue *q);
-void *queue_pop_back(queue *q);
+void *ff_queue_pop_front(FFQueue *q);
+void *ff_queue_pop_back(FFQueue *q);
 
 #endif

--- a/libavfilter/dnn/safe_queue.h
+++ b/libavfilter/dnn/safe_queue.h
@@ -21,16 +21,16 @@
 #ifndef AVFILTER_DNN_SAFE_QUEUE_H
 #define AVFILTER_DNN_SAFE_QUEUE_H
 
-typedef struct _safe_queue safe_queue;
+typedef struct FFSafeQueue FFSafeQueue;
 
-safe_queue *safe_queue_create(void);
-void safe_queue_destroy(safe_queue *sq);
+FFSafeQueue *ff_safe_queue_create(void);
+void ff_safe_queue_destroy(FFSafeQueue *sq);
 
-size_t safe_queue_size(safe_queue *sq);
+size_t ff_safe_queue_size(FFSafeQueue *sq);
 
-void safe_queue_push_front(safe_queue *sq, void *v);
-void safe_queue_push_back(safe_queue *sq, void *v);
+void ff_safe_queue_push_front(FFSafeQueue *sq, void *v);
+void ff_safe_queue_push_back(FFSafeQueue *sq, void *v);
 
-void *safe_queue_pop_front(safe_queue *sq);
+void *ff_safe_queue_pop_front(FFSafeQueue *sq);
 
 #endif


### PR DESCRIPTION
The prefix for symbols not exported from the library and not
local to one translation unit is ff_ (or FF for types).

Signed-off-by: Guo, Yejun <yejun.guo@intel.com>