### PR TITLE
avcodec/qsv_enc: do not reuse enc_ctrl from previous frames

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1249,6 +1249,8 @@ static void clear_unused_frames(QSVEncContext *q)
     while (cur) {
         if (cur->used && !cur->surface.Data.Locked) {
             free_encoder_ctrl_payloads(&cur->enc_ctrl);
+            //do not reuse enc_ctrl from previous frame
+            memset(&cur->enc_ctrl, 0, sizeof(cur->enc_ctrl));
             if (cur->frame->format == AV_PIX_FMT_QSV) {
                 av_frame_unref(cur->frame);
             }


### PR DESCRIPTION
fixes http://trac.ffmpeg.org/ticket/8857

If we do not clear the enc_ctrl, we will reuse previous frames' data like FrameType.