### PR TITLE
libavcodec/qsvdec: skip non-key frame after "seek" function

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -616,6 +616,13 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
     }
 
     if (!q->initialized) {
+        
+        /*  skip non-key frame when decoder is reinitialized. 
+        Adding before will skip all the non-key frames so add 
+        it here */
+        if (ret < 0)
+            return ret;
+
         ret = qsv_decode_init_context(avctx, q, &param);
         if (ret < 0)
             goto reinit_fail;


### PR DESCRIPTION
Fix #9095. Qsv decoder assume that after calling seek funcion, the first
frame should be key frame. However this is not true for some videos. If
the frame is not key frame after seek(), there will error. Conditional
statements are added to skip these frame until reading a key frame.

@xhaihao @xuguangxin @feiwan1 please help me to review.

thanks