### PR TITLE
libavcodec/vaapi_encode: fix #7706. Call vaapi encoder func to async way

### DIFF
--- a/libavcodec/vaapi_encode.h
+++ b/libavcodec/vaapi_encode.h
@@ -29,6 +29,7 @@
 
 #include "libavutil/hwcontext.h"
 #include "libavutil/hwcontext_vaapi.h"
+#include "libavutil/fifo.h"
 
 #include "avcodec.h"
 #include "hwconfig.h"
@@ -345,6 +346,8 @@ typedef struct VAAPIEncodeContext {
     int             roi_warned;
 
     AVFrame         *frame;
+
+    AVFifoBuffer *encode_fifo;
 } VAAPIEncodeContext;
 
 enum {


### PR DESCRIPTION
After commit 5fdcf85bbffe7451c2, vaapi encoder's performance drop
20~30%. One reason is that vaRenderPicture() and vaSyncSurface() are
called at the same time (vaRenderPicture() always followed by a
vaSyncSurface()). Now I changed them to be called in a
asynchronous way, which will make better use of hardware.

Another reason of performance drop is that in old version, ffmpeg-vaapi
use CQP as default while the ffmpeg-vaapi of lastest version does not,
so the same command line will have a even bigger performance gap. To
test this patch you'd better specify the bitrate (-b:v XXX).

Signed-off-by: Wenbin CHEN <wenbin.chen@intel.com>