### PR TITLE
libavcodec/qsvdec: change the get surface logic

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -513,7 +513,7 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
             return AVERROR_BUG;
         }
 
-        out_frame->queued = 1;
+        out_frame->queued += 1;
         av_fifo_generic_write(q->async_fifo, &out_frame, sizeof(out_frame), NULL);
         av_fifo_generic_write(q->async_fifo, &sync,      sizeof(sync),      NULL);
     } else {
@@ -526,7 +526,7 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
 
         av_fifo_generic_read(q->async_fifo, &out_frame, sizeof(out_frame), NULL);
         av_fifo_generic_read(q->async_fifo, &sync,      sizeof(sync),      NULL);
-        out_frame->queued = 0;
+        out_frame->queued -= 1;
 
         if (avctx->pix_fmt != AV_PIX_FMT_QSV) {
             do {


### PR DESCRIPTION
MSDK vc1 and av1 sometimes output frame into the same suface, but
ffmpeg-qsv assume the surface will be used only once, so it will
unref the frame when it receives the outpur surface. Now change
it to allocate frame at runtime but unref when whole decoding process
end.

Signed-off-by Wenbin Chen <wenbin.chen@intel.com>