### PR TITLE
libavcodec/qsvenc: add more ChromaFormat support for mjpeg-qsv

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -445,7 +445,8 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
     q->param.mfx.FrameInfo.CropH          = avctx->height;
     q->param.mfx.FrameInfo.AspectRatioW   = avctx->sample_aspect_ratio.num;
     q->param.mfx.FrameInfo.AspectRatioH   = avctx->sample_aspect_ratio.den;
-    q->param.mfx.FrameInfo.ChromaFormat   = MFX_CHROMAFORMAT_YUV420;
+    q->param.mfx.FrameInfo.ChromaFormat   = MFX_CHROMAFORMAT_YUV420 +
+                                            !desc->log2_chroma_w + !desc->log2_chroma_h;
     q->param.mfx.FrameInfo.BitDepthLuma   = desc->comp[0].depth;
     q->param.mfx.FrameInfo.BitDepthChroma = desc->comp[0].depth;
     q->param.mfx.FrameInfo.Shift          = desc->comp[0].depth > 8;


### PR DESCRIPTION
ChromaForamt for mjpeg-qsv is always set to yuv420, and this will be
wrong when encode other pixel format (for example yuyv422). I change
this assignment to be adaptive to pix_fmt.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>

Try to fix the jpeg encode failed cases in full rount test.