### PR TITLE
libavfilter/qsvvpp: change the output frame's width and height

### DIFF
--- a/libavfilter/qsvvpp.c
+++ b/libavfilter/qsvvpp.c
@@ -476,6 +476,9 @@ static QSVFrame *query_frame(QSVVPPContext *s, AVFilterLink *outlink)
             return NULL;
         }
 
+        out_frame->frame->width  = outlink->w;
+        out_frame->frame->height = outlink->h;
+
         out_frame->surface = (mfxFrameSurface1 *)out_frame->frame->data[3];
     } else {
         /* Get a frame with aligned dimensions.


### PR DESCRIPTION
qsvvpp align the width and height with 16, and that may lead to error.
For example, when we use qsvvpp to resize frame to 1080p, qsvvpp will
align frame to 1088 which is different from the height of
encoder (1080). Now I assign the out_link's width and height to output's
frame to overwrite the hw_frame_ctx's resolution.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>

Try to fix some transcode failed cases in full round test.