### PR TITLE
libavcodec/vaapi_encode_vp9.c:set a defualt value for log2_tile_columns

### DIFF
--- a/libavcodec/vaapi_encode_vp9.c
+++ b/libavcodec/vaapi_encode_vp9.c
@@ -31,6 +31,7 @@
 
 #define VP9_MAX_QUANT 255
 
+#define VP9_MAX_TILE_WIDTH 4096
 
 typedef struct VAAPIEncodeVP9Picture {
     int slot;
@@ -82,9 +83,16 @@ static int vaapi_encode_vp9_init_picture_params(AVCodecContext *avctx,
     VAAPIEncodeVP9Picture          *hpic = pic->priv_data;
     VAEncPictureParameterBufferVP9 *vpic = pic->codec_picture_params;
     int i;
+    int num_tile_columns;
 
     vpic->reconstructed_frame = pic->recon_surface;
     vpic->coded_buf = pic->output_buffer;
+
+    // Maximum width of a tile in units of superblocks is MAX_TILE_WIDTH_B64(64)
+    // So the number of tile columns is related to the width of the picture.
+    // We set the minimum possible number for num_tile_columns as defualt value.
+    num_tile_columns = (vpic->frame_width_src + VP9_MAX_TILE_WIDTH - 1) / VP9_MAX_TILE_WIDTH;
+    vpic->log2_tile_columns = num_tile_columns == 1 ? 0 : av_log2(num_tile_columns - 1) + 1;
 
     switch (pic->type) {
     case PICTURE_TYPE_IDR:


### PR DESCRIPTION
Maximum width of a tile in units of superblocks is 64,
So the number of tile columns is related to the width of the picture.
We should set a defualt value for log2_tile_columns
to to avoid errors in video coding with width over 4096.

Signed-off-by: Zhang yuankun <yuankunx.zhang@intel.com>