### PR TITLE
fftools/ffmpeg_qsv:Change width and height of hw_frame_ctx to original value

### DIFF
--- a/fftools/ffmpeg_qsv.c
+++ b/fftools/ffmpeg_qsv.c
@@ -90,8 +90,8 @@ int qsv_init(AVCodecContext *s)
     frames_ctx   = (AVHWFramesContext*)ist->hw_frames_ctx->data;
     frames_hwctx = frames_ctx->hwctx;
 
-    frames_ctx->width             = FFALIGN(s->coded_width,  32);
-    frames_ctx->height            = FFALIGN(s->coded_height, 32);
+    frames_ctx->width             = s->width;
+    frames_ctx->height            = s->height;
     frames_ctx->format            = AV_PIX_FMT_QSV;
     frames_ctx->sw_format         = s->sw_pix_fmt;
     frames_ctx->initial_pool_size = 64 + s->extra_hw_frames;

--- a/libavfilter/qsvvpp.c
+++ b/libavfilter/qsvvpp.c
@@ -561,8 +561,8 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
         out_frames_hwctx = out_frames_ctx->hwctx;
 
         out_frames_ctx->format            = AV_PIX_FMT_QSV;
-        out_frames_ctx->width             = FFALIGN(outlink->w, 32);
-        out_frames_ctx->height            = FFALIGN(outlink->h, 32);
+        out_frames_ctx->width             = outlink->w;
+        out_frames_ctx->height            = outlink->h;
         out_frames_ctx->sw_format         = s->out_sw_format;
         out_frames_ctx->initial_pool_size = 64;
         if (avctx->extra_hw_frames > 0)

--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -201,8 +201,8 @@ static int init_out_pool(AVFilterContext *ctx,
     out_frames_hwctx = out_frames_ctx->hwctx;
 
     out_frames_ctx->format            = AV_PIX_FMT_QSV;
-    out_frames_ctx->width             = FFALIGN(out_width,  16);
-    out_frames_ctx->height            = FFALIGN(out_height, 16);
+    out_frames_ctx->width             = out_width;
+    out_frames_ctx->height            = out_height;
     out_frames_ctx->sw_format         = out_format;
     out_frames_ctx->initial_pool_size = 4;
 


### PR DESCRIPTION
We use w/h from vaapi hw_frame_ctx to create libva surfaces and we use Param
to init mfx-codec or mfx-vpp. All this value are already aligned value,
so we needn't to aligned width and height in qsv hw_frame_ctx.
We use hw_frame_ctx to create AVFrame, we use hw_frame_ctx->w/h to
configure crop_w/h in hwcontext_qsv.c/qsv_init_surface() function. And
this value should be original width and height, so I change the qsv's
hw_frame_ctx->width/height to original value because of these two reasons.

Signed-off-by: Wenbin Chen wenbin.chen@intel.com