### PR TITLE
lavfi/dnn/dnn_backend_tf.h: Add Documentation

### DIFF
--- a/libavfilter/dnn/dnn_backend_tf.h
+++ b/libavfilter/dnn/dnn_backend_tf.h
@@ -29,11 +29,57 @@
 
 #include "../dnn_interface.h"
 
+/**
+ * @brief Load model from the model.
+ *
+ * It allocates and initializes the DNN model
+ * with the model parameters. If the graph cannot
+ * be read by the TensorFlow C API, the function
+ * tries loading it with native backend.
+ *
+ * @param model_filename name of the model file to load
+ * @param func_type function type of model
+ * @param options model execution options
+ * @param filter_ctx filter context
+ * @return The pointer to DNNModel instance of the loaded model
+ * @retval NULL if the model cannot be loaded.
+ * All allocated are freed by the function.
+ */
 DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
+/**
+ * @brief Execute TensorFlow model in synchronous mode.
+ *
+ * It parses the data from the input frame, preprocesses
+ * the input frame data if required and fills the input
+ * Tensor. Then it run the TensorFlow session and fills
+ * the output after post processing it if required.
+ *
+ * Currently only single output is supported.
+ *
+ * @param model name of the model file to load
+ * @param input_name function type of model
+ * @param in_frame input frame
+ * @param output_names TensorFlow operation names
+ * @param nb_output number of outputs from the model
+ * @param out_frame output frame
+ * @return Status of model execution
+ * @retval DNN_SUCCESS if the execution succeeds
+ * @retval DNN_ERROR if the execution fails.
+ * All allocated are freed by the function.
+ */
 DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, const char *input_name, AVFrame *in_frame,
                                       const char **output_names, uint32_t nb_output, AVFrame *out_frame);
 
+/**
+ * @brief Free the DNN model.
+ *
+ * If model isn't freed, it frees the TensorFlow
+ * graph and status instances. It also closes and
+ * deletes the TensorFlow session.
+ *
+ * @param model DNNModel instance of the loaded model
+ */
 void ff_dnn_free_model_tf(DNNModel **model);
 
 #endif


### PR DESCRIPTION
## Description

Add documentation to `dnn_backend_tf.h` in `libavfilter/dnn`

@guoyejun, please review these changes. 

Also, I wanted to ask should I document the functions in `dnn_backend_tf.c`, which are not directly accessible outside the module?