### PR TITLE
lavfi: Add Documentation to Native Backend Layers

### DIFF
--- a/libavfilter/dnn/dnn_backend_native_layer_avgpool.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_avgpool.h
@@ -33,7 +33,35 @@ typedef struct AvgPoolParams{
     DNNPaddingParam padding_method;
 } AvgPoolParams;
 
+/**
+ * @brief Load Average Pooling Layer.
+ *
+ * It assigns the Average Pooling layer with AvgPoolParams
+ * after parsing from the model file context.
+ *
+ * @param layer pointer to the DNN layer instance
+ * @param model_file_context pointer to model file context
+ * @param file_size model file size to check if data is read
+ * correctly from the model file
+ * @param operands_num operand count of the whole model to
+ * check if data is read correctly from the model file
+ * @return number of bytes read from the model file
+ * @retval 0 if out of memory or an error occurs
+ */
 int ff_dnn_load_layer_avg_pool(Layer *layer, AVIOContext *model_file_context, int file_size, int operands_num);
+
+/**
+ * @brief Execute the Average Pooling Layer.
+ * Padding in channel dimensions is currently not supported.
+ *
+ * @param operands all operands for the model
+ * @param input_operand_indexes input operand indexes for this layer
+ * @param output_operand_index output operand index for this layer
+ * @param parameters average pooling parameters
+ * @param ctx pointer to Native model context for logging
+ * @retval 0 if the execution succeeds
+ * @retval DNN_ERROR if the execution fails
+ */
 int ff_dnn_execute_layer_avg_pool(DnnOperand *operands, const int32_t *input_operand_indexes,
                                   int32_t output_operand_index, const void *parameters, NativeContext *ctx);
 

--- a/libavfilter/dnn/dnn_backend_native_layer_conv2d.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_conv2d.h
@@ -34,7 +34,34 @@ typedef struct ConvolutionalParams{
     float *biases;
 } ConvolutionalParams;
 
+/**
+ * @brief Load the 2D Convolution Layer.
+ *
+ * It assigns the 2D convolution layer with ConvolutionalParams
+ * after parsing from the model file context.
+ *
+ * @param layer pointer to the DNN layer instance
+ * @param model_file_context pointer to model file context
+ * @param file_size model file size to check if data is read
+ * correctly from the model file
+ * @param operands_num operand count of the whole model to
+ * check if data is read correctly from the model file
+ * @return number of bytes read from the model file
+ * @retval 0 if out of memory or an error occurs
+ */
 int ff_dnn_load_layer_conv2d(Layer *layer, AVIOContext *model_file_context, int file_size, int operands_num);
+
+/**
+ * @brief Execute the 2D Convolution Layer.
+ *
+ * @param operands all operands for the model
+ * @param input_operand_indexes input operand indexes for this layer
+ * @param output_operand_index output operand index for this layer
+ * @param parameters convolution parameters
+ * @param ctx pointer to Native model context for logging
+ * @retval 0 if the execution succeeds
+ * @retval DNN_ERROR if the execution fails
+ */
 int ff_dnn_execute_layer_conv2d(DnnOperand *operands, const int32_t *input_operand_indexes,
                                 int32_t output_operand_index, const void *parameters, NativeContext *ctx);
 #endif

--- a/libavfilter/dnn/dnn_backend_native_layer_dense.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_dense.h
@@ -31,7 +31,34 @@ typedef struct DenseParams{
     float *biases;
 } DenseParams;
 
+/**
+ * @brief Load the Densely-Connected Layer.
+ *
+ * It assigns the densely connected layer with DenseParams
+ * after parsing from the model file context.
+ *
+ * @param layer pointer to the DNN layer instance
+ * @param model_file_context pointer to model file context
+ * @param file_size model file size to check if data is read
+ * correctly from the model file
+ * @param operands_num operand count of the whole model to
+ * check if data is read correctly from the model file
+ * @return number of bytes read from the model file
+ * @retval 0 if out of memory or an error occurs
+ */
 int ff_dnn_load_layer_dense(Layer *layer, AVIOContext *model_file_context, int file_size, int operands_num);
+
+/**
+ * @brief Execute the Densely-Connected Layer.
+ *
+ * @param operands all operands for the model
+ * @param input_operand_indexes input operand indexes for this layer
+ * @param output_operand_index output operand index for this layer
+ * @param parameters dense layer parameters
+ * @param ctx pointer to Native model context for logging
+ * @retval 0 if the execution succeeds
+ * @retval DNN_ERROR if the execution fails
+ */
 int ff_dnn_execute_layer_dense(DnnOperand *operands, const int32_t *input_operand_indexes,
                                int32_t output_operand_index, const void *parameters, NativeContext *ctx);
 #endif

--- a/libavfilter/dnn/dnn_backend_native_layer_depth2space.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_depth2space.h
@@ -34,7 +34,37 @@ typedef struct DepthToSpaceParams{
     int block_size;
 } DepthToSpaceParams;
 
+/**
+ * @brief Load the Depth to Space Layer.
+ *
+ * It assigns the depth to space layer with DepthToSpaceParams
+ * after parsing from the model file context.
+ *
+ * @param layer pointer to the DNN layer instance
+ * @param model_file_context pointer to model file context
+ * @param file_size model file size to check if data is read
+ * correctly from the model file
+ * @param operands_num operand count of the whole model to
+ * check if data is read correctly from the model file
+ * @return number of bytes read from the model file
+ * @retval 0 if an error occurs or out of memory
+ */
 int ff_dnn_load_layer_depth2space(Layer *layer, AVIOContext *model_file_context, int file_size, int operands_num);
+
+/**
+ * @brief Execute the Depth to Space Layer.
+ *
+ * It rearranges the input data from depth into spatial
+ * form by applying Depth to Space transformation.
+ *
+ * @param operands all operands for the model
+ * @param input_operand_indexes input operand indexes for this layer
+ * @param output_operand_index output operand index for this layer
+ * @param parameters depth to space layer parameters
+ * @param ctx pointer to Native model context for logging
+ * @retval 0 if the execution succeeds
+ * @retval DNN_ERROR if the execution fails
+ */
 int ff_dnn_execute_layer_depth2space(DnnOperand *operands, const int32_t *input_operand_indexes,
                                      int32_t output_operand_index, const void *parameters, NativeContext *ctx);
 

--- a/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
@@ -54,7 +54,37 @@ typedef struct DnnLayerMathUnaryParams{
     DNNMathUnaryOperation un_op;
 } DnnLayerMathUnaryParams;
 
+/**
+ * @brief Load the Unary Math Layer.
+ *
+ * It assigns the unary math layer with DnnLayerMathUnaryParams
+ * after parsing from the model file context.
+ *
+ * @param layer pointer to the DNN layer instance
+ * @param model_file_context pointer to model file context
+ * @param file_size model file size to check if data is read
+ * correctly from the model file
+ * @param operands_num operand count of the whole model to
+ * check if data is read correctly from the model file
+ * @return number of bytes read from the model file
+ * @retval 0 if out of memory or an error occurs
+ */
 int ff_dnn_load_layer_math_unary(Layer *layer, AVIOContext *model_file_context, int file_size, int operands_num);
+
+/**
+ * @brief Execute the Unary Math Layer.
+ *
+ * It applies the unary operator parsed while
+ * loading to the given input operands.
+ *
+ * @param operands all operands for the model
+ * @param input_operand_indexes input operand indexes for this layer
+ * @param output_operand_index output operand index for this layer
+ * @param parameters unary math layer parameters
+ * @param ctx pointer to Native model context for logging
+ * @retval 0 if the execution succeeds
+ * @retval DNN_ERROR if the execution fails
+ */
 int ff_dnn_execute_layer_math_unary(DnnOperand *operands, const int32_t *input_operand_indexes,
                                     int32_t output_operand_index, const void *parameters, NativeContext *ctx);
 


### PR DESCRIPTION
## Description

Add documentation for the Average Pooling Layer.

## Questions

@guoyejun, I have a few questions regarding the Average Pooling Layer. 

1. Is the `dnn_size` returned by `ff_dnn_load_layer_avg_pool` the size of the layer or the size of parameters? 
2. I noticed the padding method in the Average Pooling Layer can be either `SAME` or `VALID`, but this isn't checking until the execution starts. Should we have an exclusive check for this while loading the layer?
3. Also in `ff_dnn_execute_layer_avg_pool`, if the execution is successful, the function returns `0`. But when it fails, it returns `DNN_ERROR`. I think it would be better to return `DNN_SUCCESS` though technically both are the same.