### PR TITLE
vaapi_decode: support dynamically frame pool resizing.

### DIFF
--- a/libavcodec/vaapi_decode.c
+++ b/libavcodec/vaapi_decode.c
@@ -572,22 +572,24 @@ static int vaapi_decode_make_config(AVCodecContext *avctx,
         if (err < 0)
             goto fail;
 
-        frames->initial_pool_size = 1;
-        // Add per-codec number of surfaces used for storing reference frames.
-        switch (avctx->codec_id) {
-        case AV_CODEC_ID_H264:
-        case AV_CODEC_ID_HEVC:
-            frames->initial_pool_size += 16;
-            break;
-        case AV_CODEC_ID_VP9:
-        case AV_CODEC_ID_AV1:
-            frames->initial_pool_size += 8;
-            break;
-        case AV_CODEC_ID_VP8:
-            frames->initial_pool_size += 3;
-            break;
-        default:
-            frames->initial_pool_size += 2;
+        if (hwctx->driver_quirks & AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING) {
+            frames->initial_pool_size = 1;
+            // Add per-codec number of surfaces used for storing reference frames.
+            switch (avctx->codec_id) {
+            case AV_CODEC_ID_H264:
+            case AV_CODEC_ID_HEVC:
+                frames->initial_pool_size += 16;
+                break;
+            case AV_CODEC_ID_VP9:
+            case AV_CODEC_ID_AV1:
+                frames->initial_pool_size += 8;
+                break;
+            case AV_CODEC_ID_VP8:
+                frames->initial_pool_size += 3;
+                break;
+            default:
+                frames->initial_pool_size += 2;
+            }
         }
     }
 

--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -475,8 +475,11 @@ static AVBufferRef *vaapi_pool_alloc(void *opaque, size_t size)
     AVBufferRef *ref;
 
     if (hwfc->initial_pool_size > 0 &&
-        avfc->nb_surfaces >= hwfc->initial_pool_size)
+        avfc->nb_surfaces >= hwfc->initial_pool_size) {
+        av_log(hwfc, AV_LOG_ERROR, "allocated surfaces count(%d) > pool_size(%d)\n",
+               avfc->nb_surfaces,  hwfc->initial_pool_size);
         return NULL;
+    }
 
     vas = vaCreateSurfaces(hwctx->display, ctx->rt_format,
                            hwfc->width, hwfc->height,

--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -331,23 +331,26 @@ static const struct {
     const char *match_string;
     unsigned int quirks;
 } vaapi_driver_quirks_table[] = {
-#if !VA_CHECK_VERSION(1, 0, 0)
-    // The i965 driver did not conform before version 2.0.
+    // The i965 driver did not conform RENDER_PARAM_BUFFERS before version 2.0.
     {
         "Intel i965 (Quick Sync)",
         "i965",
-        AV_VAAPI_DRIVER_QUIRK_RENDER_PARAM_BUFFERS,
-    },
+#if !VA_CHECK_VERSION(1, 0, 0)
+        AV_VAAPI_DRIVER_QUIRK_RENDER_PARAM_BUFFERS | AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING,
+#else
+        AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING,
 #endif
+    },
+
     {
         "Intel iHD",
         "ubit",
-        AV_VAAPI_DRIVER_QUIRK_ATTRIB_MEMTYPE,
+        AV_VAAPI_DRIVER_QUIRK_ATTRIB_MEMTYPE | AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING,
     },
     {
         "VDPAU wrapper",
         "Splitted-Desktop Systems VDPAU backend for VA-API",
-        AV_VAAPI_DRIVER_QUIRK_SURFACE_ATTRIBUTES,
+        AV_VAAPI_DRIVER_QUIRK_SURFACE_ATTRIBUTES | AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING,
     },
 };
 

--- a/libavutil/hwcontext_vaapi.h
+++ b/libavutil/hwcontext_vaapi.h
@@ -58,6 +58,12 @@ enum {
      * and the results of the vaQuerySurfaceAttributes() call will be faked.
      */
     AV_VAAPI_DRIVER_QUIRK_SURFACE_ATTRIBUTES = (1 << 3),
+
+    /**
+     * The driver does not support dynamically frame pool resizing.
+     * We need to provide all va surfaces at vaCreateContext
+     */
+    AV_VAAPI_DRIVER_QUIRK_FRAME_POOL_RESIZING = (1 << 4),
 };
 
 /**


### PR DESCRIPTION
Two benefits of this patch set:
    1. Save memory. If we play an 8k hevc, previous code we allocate 50M * 20(1 + 16 + 3) = 1G memory. 16 is a waste for most playback cases.
    2. Allow downstream cache more frames. A downstream lookahead encoder will cache some frames. 20 may not enough for it.

This patch set will fix the following command
ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -i 100frames.264  -vf reverse -an -f null -

