### PR TITLE
libavcodec/qsvenc: fix system memory input error.

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1357,6 +1357,10 @@ static int submit_frame(QSVEncContext *q, const AVFrame *frame,
         qf->surface.Data.PitchLow  = qf->frame->linesize[0];
         qf->surface.Data.Y         = qf->frame->data[0];
         qf->surface.Data.UV        = qf->frame->data[1];
+        if (frame->format == AV_PIX_FMT_NV12)
+            qf->surface.Data.V         = qf->surface.Data.UV + 1;
+        else if (frame->format == AV_PIX_FMT_P010)
+            qf->surface.Data.V         = qf->surface.Data.UV + 2;
     }
 
     qf->surface.Data.TimeStamp = av_rescale_q(frame->pts, q->avctx->time_base, (AVRational){1, 90000});


### PR DESCRIPTION
vp9_qsv encoder check the UV and V value in surface when encode
frame in system memory. Assign UV+1 to V just as what sample_encode
does.

Fix command line: ffmpeg -i inputvideo -c:v vp9_qsv output.ivf

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>