### PR TITLE
avcodec/vaapi_av1: correct data size when create slice data buffer

### DIFF
--- a/libavcodec/vaapi_av1.c
+++ b/libavcodec/vaapi_av1.c
@@ -292,7 +292,7 @@ static int vaapi_av1_decode_slice(AVCodecContext *avctx,
         err = ff_vaapi_decode_make_slice_buffer(avctx, pic, &slice_param,
                                                 sizeof(VASliceParameterBufferAV1),
                                                 buffer,
-                                                s->tile_group_info[i].tile_size);
+                                                size);
         if (err) {
             ff_vaapi_decode_cancel(avctx, pic);
             return err;


### PR DESCRIPTION
Set all tiles size to create slice data buffer, hardware will use
slice_data_offset/slice_data_size in slice parameter buffer to get
each tile's data.

This change will let it success to decode clip which has multi
tiles data inside one OBU.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>