### PR TITLE
Async Support for TensorFlow Backend

### DIFF
--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -122,3 +122,23 @@ DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_
 #endif
     return DNN_SUCCESS;
 }
+
+DNNAsyncStatusType ff_dnn_get_async_result_common(Queue *task_queue, AVFrame **in, AVFrame **out)
+{
+    TaskItem *task = ff_queue_peek_front(task_queue);
+
+    if (!task) {
+        return DAST_EMPTY_QUEUE;
+    }
+
+    if (task->inference_done != task->inference_todo) {
+        return DAST_NOT_READY;
+    }
+
+    *in = task->in_frame;
+    *out = task->out_frame;
+    ff_queue_pop_front(task_queue);
+    av_freep(&task);
+
+    return DAST_SUCCESS;
+}

--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -142,3 +142,29 @@ DNNAsyncStatusType ff_dnn_get_async_result_common(Queue *task_queue, AVFrame **i
 
     return DAST_SUCCESS;
 }
+
+DNNReturnType ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx)
+{
+    AVFrame *in_frame = NULL;
+    AVFrame *out_frame = NULL;
+
+    in_frame = av_frame_alloc();
+    if (!in_frame) {
+        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
+        return DNN_ERROR;
+    }
+
+    out_frame = av_frame_alloc();
+    if (!out_frame) {
+        av_frame_free(&in_frame);
+        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
+        return DNN_ERROR;
+    }
+
+    in_frame->width = input_width;
+    in_frame->height = input_height;
+    exec_params->in_frame = in_frame;
+    exec_params->out_frame = out_frame;
+
+    return ff_dnn_fill_task(task, exec_params, backend_model, 0, 0);
+}

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -24,6 +24,7 @@
 #ifndef AVFILTER_DNN_DNN_BACKEND_COMMON_H
 #define AVFILTER_DNN_DNN_BACKEND_COMMON_H
 
+#include "queue.h"
 #include "../dnn_interface.h"
 #include "libavutil/thread.h"
 
@@ -121,5 +122,19 @@ DNNReturnType ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module);
  * @retval DNN_ERROR in case async inference cannot be started
  */
 DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module);
+
+/**
+ * Extract input and output frame from the Task Queue after
+ * asynchronous inference.
+ *
+ * @param task_queue pointer to the task queue of the backend
+ * @param in double pointer to the input frame
+ * @param out double pointer to the output frame
+ *
+ * @retval DAST_EMPTY_QUEUE if task queue is empty
+ * @retval DAST_NOT_READY if inference not completed yet.
+ * @retval DAST_SUCCESS if result successfully extracted
+ */
+DNNAsyncStatusType ff_dnn_get_async_result_common(Queue *task_queue, AVFrame **in, AVFrame **out);
 
 #endif

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -137,4 +137,20 @@ DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_
  */
 DNNAsyncStatusType ff_dnn_get_async_result_common(Queue *task_queue, AVFrame **in, AVFrame **out);
 
+/**
+ * Allocate input and output frames and fill the Task
+ * with execution parameters.
+ *
+ * @param task pointer to the allocated task
+ * @param exec_params pointer to execution parameters
+ * @param backend_model void pointer to the backend model
+ * @param input_height height of input frame
+ * @param input_width width of input frame
+ * @param ctx pointer to the backend context
+ *
+ * @retval DNN_SUCCESS if successful
+ * @retval DNN_ERROR if allocation fails
+ */
+DNNReturnType ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx);
+
 #endif

--- a/libavfilter/dnn/dnn_backend_openvino.c
+++ b/libavfilter/dnn/dnn_backend_openvino.c
@@ -32,7 +32,6 @@
 #include "libavutil/avstring.h"
 #include "libavutil/detection_bbox.h"
 #include "../internal.h"
-#include "queue.h"
 #include "safe_queue.h"
 #include <c_api/ie_c_api.h>
 #include "dnn_backend_common.h"
@@ -883,22 +882,7 @@ DNNReturnType ff_dnn_execute_model_async_ov(const DNNModel *model, DNNExecBasePa
 DNNAsyncStatusType ff_dnn_get_async_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out)
 {
     OVModel *ov_model = model->model;
-    TaskItem *task = ff_queue_peek_front(ov_model->task_queue);
-
-    if (!task) {
-        return DAST_EMPTY_QUEUE;
-    }
-
-    if (task->inference_done != task->inference_todo) {
-        return DAST_NOT_READY;
-    }
-
-    *in = task->in_frame;
-    *out = task->out_frame;
-    ff_queue_pop_front(ov_model->task_queue);
-    av_freep(&task);
-
-    return DAST_SUCCESS;
+    return ff_dnn_get_async_result_common(ov_model->task_queue, in, out);
 }
 
 DNNReturnType ff_dnn_flush_ov(const DNNModel *model)

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -310,35 +310,19 @@ static DNNReturnType get_output_tf(void *model, const char *input_name, int inpu
     DNNReturnType ret;
     TFModel *tf_model = model;
     TFContext *ctx = &tf_model->ctx;
-    AVFrame *in_frame = av_frame_alloc();
-    AVFrame *out_frame = NULL;
     TaskItem task;
     TFRequestItem *request;
+    DNNExecBaseParams exec_params = {
+        .input_name     = input_name,
+        .output_names   = &output_name,
+        .nb_output      = 1,
+        .in_frame       = NULL,
+        .out_frame      = NULL,
+    };
 
-    if (!in_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
-        ret = DNN_ERROR;
+    if (ff_dnn_fill_gettingoutput_task(&task, &exec_params, tf_model, input_height, input_width, ctx) != DNN_SUCCESS) {
         goto err;
     }
-
-    out_frame = av_frame_alloc();
-    if (!out_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
-        ret = DNN_ERROR;
-        goto err;
-    }
-
-    in_frame->width = input_width;
-    in_frame->height = input_height;
-
-    task.do_ioproc = 0;
-    task.async = 0;
-    task.input_name = input_name;
-    task.in_frame = in_frame;
-    task.output_names = &output_name;
-    task.out_frame = out_frame;
-    task.model = tf_model;
-    task.nb_output = 1;
 
     if (extract_inference_from_task(&task, tf_model->inference_queue) != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
@@ -354,12 +338,12 @@ static DNNReturnType get_output_tf(void *model, const char *input_name, int inpu
     }
 
     ret = execute_model_tf(request, tf_model->inference_queue);
-    *output_width = out_frame->width;
-    *output_height = out_frame->height;
+    *output_width = task.out_frame->width;
+    *output_height = task.out_frame->height;
 
 err:
-    av_frame_free(&out_frame);
-    av_frame_free(&in_frame);
+    av_frame_free(&task.out_frame);
+    av_frame_free(&task.in_frame);
     return ret;
 }
 

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -135,6 +135,9 @@ static void tf_free_request(TFInferRequest *request)
 static TFInferRequest *tf_create_inference_request(void)
 {
     TFInferRequest *infer_request = av_malloc(sizeof(TFInferRequest));
+    if (!infer_request) {
+        return NULL;
+    }
     infer_request->tf_outputs = NULL;
     infer_request->tf_input = NULL;
     infer_request->input_tensor = NULL;

--- a/libavfilter/dnn/dnn_backend_tf.h
+++ b/libavfilter/dnn/dnn_backend_tf.h
@@ -32,6 +32,9 @@
 DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
 DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
+DNNReturnType ff_dnn_execute_model_async_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
+DNNAsyncStatusType ff_dnn_get_async_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out);
+DNNReturnType ff_dnn_flush_tf(const DNNModel *model);
 
 void ff_dnn_free_model_tf(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -48,6 +48,9 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
     #if (CONFIG_LIBTENSORFLOW == 1)
         dnn_module->load_model = &ff_dnn_load_model_tf;
         dnn_module->execute_model = &ff_dnn_execute_model_tf;
+        dnn_module->execute_model_async = &ff_dnn_execute_model_async_tf;
+        dnn_module->get_async_result = &ff_dnn_get_async_result_tf;
+        dnn_module->flush = &ff_dnn_flush_tf;
         dnn_module->free_model = &ff_dnn_free_model_tf;
     #else
         av_freep(&dnn_module);

--- a/libavfilter/dnn/queue.h
+++ b/libavfilter/dnn/queue.h
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stddef.h>
 
 #ifndef AVFILTER_DNN_QUEUE_H
 #define AVFILTER_DNN_QUEUE_H


### PR DESCRIPTION
### Patch Set Description

This patchset is a part of necessary deliverables in the GSoC project [Async Support for TensorFlow Backend in FFmpeg](https://summerofcode.withgoogle.com/projects/#5224576843251712).

**Objective**: Asynchronous Support for TensorFlow backend
**Parts under this deliverable**:
    - Switch the execution mode to `TFRequestItem` based inference.
    - Implementing a standard asynchronous inference module `DNNAsyncExecModule` for use across the TF and Native backends.
    - Implement async mode in the TensorFlow backend.

### Earlier Merged Patches in this patchset

The below patches move the `TaskItem` and `InferenceItem` from the OpenVINO backend to the `dnn_backend_common` and adjust them for shared use across the three backends. Then we define the `TFRequestItem` with execution parameters and switch the execution mechanism in the TensorFlow backend to `TFRequestItem` based inference.

f5ab890 lavfi/dnn: Extract TaskItem and InferenceItem from OpenVino Backend
446b4f7 lavfi/dnn: Convert output_name to char** in TaskItem
9675ebb lavfi/dnn: Add nb_output to TaskItem
6b961f7 lavfi/dnn: Use uint8_t for async and do_ioproc in TaskItems
5509235 lavfi/dnn: Fill Task using Common Function
68cf14d lavfi/dnn_backend_tf: TaskItem Based Inference
a4de605 lavfi/dnn_backend_tf: Add TFInferRequest and TFRequestItem
08d8b3b lavfi/dnn_backend_tf: Request-based Execution
b849228 lavfi/dnn_backend_tf: Separate function for filling RequestItem
84e4e60 lavfi/dnn_backend_tf: Separate function for Completion Callback
6f9570a lavfi/dnn_backend_tf: Error Handling

### Final Patches

The below-mentioned patches implement the `DNNAsyncExecModule` and use them in the TensorFlow backend for adding the async mode. The methodology behind the `DNNAsyncExecModule` being to execute a number of `TFRequestItem`'s (which can also be set using the backend configuration parameter `nireq`) concurrently along the main FFmpeg execution thread so that the inference requests can be executed in an asynchronous fashion.

Each `TFRequestItem` has its instance of `DNNAsyncExecModule`, which corresponds to a single thread. When `TF_SessionRun` returns, the thread routine also returns with relevant exit code, and the `TFRequestItem` is pushed back to the `request_queue`. This return status is caught when next time the same `TFRequestItem` is used for the execution. In case the previous execution failed, the error message is already printed, and we cancel all further executions by returning `DNN_ERROR`.

86f0a4f9 lavfi/dnn: Add Async Execution Mechanism and Documentation
c7165785 lavfi/dnn: Common Function to Get Async Result in DNN Backends
e6ae8fc1 lavfi/dnn_backend_tf: TFInferRequest Execution and Documentation
0985e928 lavfi/dnn: Async Support for TensorFlow Backend
a3db9b54 lavfi/dnn_backend_tf: Error Handling for execute_model_tf
4d627ace lavfi/dnn_backend_tf: Add TF_Status to TFRequestItem
009b2e5b lavfi/dnn: Extract Common Parts from get_output functions
371e5672 lavfi/dnn_backend_tf: Error Handling for tf_create_inference_request
2063745a lavfi/dnn: DNNAsyncExecModule Execution Failure Handling