### PR TITLE
ffmpeg_hw: make hardware selection for filters more user friendly

### DIFF
--- a/fftools/ffmpeg_hw.c
+++ b/fftools/ffmpeg_hw.c
@@ -527,15 +527,21 @@ int hw_device_setup_for_filter(FilterGraph *fg)
     HWDevice *dev;
     int i;
 
-    // If the user has supplied exactly one hardware device then just
-    // give it straight to every filter for convenience.  If more than
-    // one device is available then the user needs to pick one explcitly
-    // with the filter_hw_device option.
+    // Pick the last hardware device if the user doesn't pick the device for
+    // filters explicitly with the filter_hw_device option.
     if (filter_hw_device)
         dev = filter_hw_device;
-    else if (nb_hw_devices == 1)
-        dev = hw_devices[0];
-    else
+    else if (nb_hw_devices > 0) {
+        dev = hw_devices[nb_hw_devices - 1];
+
+        if (nb_hw_devices > 1)
+            av_log(NULL, AV_LOG_WARNING, "There are %d hardware devices. device "
+                   "%s of type %s is picked for filters by default. Set hardware "
+                   "device explicitly with the filter_hw_device option if device "
+                   "%s is not usable for filters.\n",
+                   nb_hw_devices, dev->name,
+                   av_hwdevice_get_type_name(dev->type), dev->name);
+    } else
         dev = NULL;
 
     if (dev) {


### PR DESCRIPTION
When a device is derived from a source device, there are at least 2
devices, and usually the derived device is the expected device, so let's
pick the last device if user doesn't specify the filter device with
filter_hw_device option

After applying this patch, the command below can work:

$> ffmpeg -init_hw_device vaapi=va:/dev/dri/renderD128 -init_hw_device
qsv=hw@va -f lavfi -i yuvtestsrc  -vf
format=nv12,hwupload=extra_hw_frames=64 -c:v h264_qsv -y out.h264