### PR TITLE
lavfi/dnn: Async Support for Native Backend

### DIFF
--- a/doc/filters.texi
+++ b/doc/filters.texi
@@ -10270,11 +10270,8 @@ and the second line is the name of label id 1, etc.
 The label id is considered as name if the label file is not provided.
 
 @item backend_configs
-Set the configs to be passed into backend
-
-@item async
-use DNN async execution if set (default: set),
-roll back to sync execution if the backend does not support async.
+Set the configs to be passed into backend. To use async execution, set async (default: set).
+Roll back to sync execution if the backend does not support async.
 
 @end table
 
@@ -10326,14 +10323,11 @@ Set the input name of the dnn network.
 Set the output name of the dnn network.
 
 @item backend_configs
-Set the configs to be passed into backend
+Set the configs to be passed into backend. To use async execution, set async (default: set).
+Roll back to sync execution if the backend does not support async.
 
 For tensorflow backend, you can set its configs with @option{sess_config} options,
 please use tools/python/tf_sess_config.py to get the configs of TensorFlow backend for your system.
-
-@item async
-use DNN async execution if set (default: set),
-roll back to sync execution if the backend does not support async.
 
 @end table
 

--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -132,3 +132,23 @@ DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_
 #endif
     return DNN_SUCCESS;
 }
+
+DNNAsyncStatusType dnn_get_async_result(Queue *task_queue, AVFrame **in, AVFrame **out)
+{
+    TaskItem *task = ff_queue_peek_front(task_queue);
+
+    if (!task) {
+        return DAST_EMPTY_QUEUE;
+    }
+
+    if (task->inference_done != task->inference_todo) {
+        return DAST_NOT_READY;
+    }
+
+    *in = task->in_frame;
+    *out = task->out_frame;
+    ff_queue_pop_front(task_queue);
+    av_freep(&task);
+
+    return DAST_SUCCESS;
+}

--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -70,6 +70,10 @@ DNNReturnType ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, v
     return DNN_SUCCESS;
 }
 
+/**
+ * Thread routine for async execution.
+ * @param args pointer to DNNAsyncExecModule module
+ */
 static void *async_thread_routine(void *args)
 {
     DNNAsyncExecModule *async_module = args;

--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -156,3 +156,29 @@ DNNAsyncStatusType dnn_get_async_result(Queue *task_queue, AVFrame **in, AVFrame
 
     return DAST_SUCCESS;
 }
+
+DNNReturnType dnn_get_output(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx)
+{
+    AVFrame *in_frame = NULL;
+    AVFrame *out_frame = NULL;
+
+    in_frame = av_frame_alloc();
+    if (!in_frame) {
+        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
+        return DNN_ERROR;
+    }
+
+    out_frame = av_frame_alloc();
+    if (!out_frame) {
+        av_frame_free(&in_frame);
+        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
+        return DNN_ERROR;
+    }
+
+    in_frame->width = input_width;
+    in_frame->height = input_height;
+    exec_params->in_frame = in_frame;
+    exec_params->out_frame = out_frame;
+
+    return ff_dnn_fill_task(task, exec_params, backend_model, 0, 0);
+}

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -29,7 +29,8 @@
 #include "libavutil/thread.h"
 
 #define DNN_BACKEND_COMMON_OPTIONS \
-    { "nireq",           "number of request",             OFFSET(options.nireq),           AV_OPT_TYPE_INT,    { .i64 = 0 },     0, INT_MAX, FLAGS },
+    { "nireq",           "number of request",             OFFSET(options.nireq),           AV_OPT_TYPE_INT,    { .i64 = 0 },     0, INT_MAX, FLAGS }, \
+    { "async",           "use DNN async inference",       OFFSET(options.async),           AV_OPT_TYPE_BOOL,   { .i64 = 1 },     0,       1, FLAGS },
 
 // one task for one function call from dnn interface
 typedef struct TaskItem {

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -148,4 +148,20 @@ DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_
  */
 DNNAsyncStatusType dnn_get_async_result(Queue *task_queue, AVFrame **in, AVFrame **out);
 
+/**
+ * Allocate input and output frames and fill the Task
+ * with execution parameters.
+ *
+ * @param task pointer to the allocated task
+ * @param exec_params pointer to execution parameters
+ * @param backend_model void pointer to the backend model
+ * @param input_height height of input frame
+ * @param input_width width of input frame
+ * @param ctx pointer to the backend context
+ *
+ * @retval DNN_SUCCESS if successful
+ * @retval DNN_ERROR if allocation fails
+ */
+DNNReturnType dnn_get_output(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx);
+
 #endif

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -24,6 +24,7 @@
 #ifndef AVFILTER_DNN_DNN_BACKEND_COMMON_H
 #define AVFILTER_DNN_DNN_BACKEND_COMMON_H
 
+#include "queue.h"
 #include "../dnn_interface.h"
 #include "libavutil/thread.h"
 
@@ -80,5 +81,6 @@ DNNReturnType ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, v
 DNNReturnType ff_init_async_attributes(DNNAsyncExecModule *async_module);
 DNNReturnType ff_destroy_async_attributes(DNNAsyncExecModule *async_module);
 DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module);
+DNNAsyncStatusType dnn_get_async_result(Queue *task_queue, AVFrame **in, AVFrame **out);
 
 #endif

--- a/libavfilter/dnn/dnn_backend_native.c
+++ b/libavfilter/dnn/dnn_backend_native.c
@@ -30,6 +30,11 @@
 #include "dnn_io_proc.h"
 #include "dnn_backend_common.h"
 
+typedef struct NativeRequestItem {
+    DnnOperand *operands;
+    InferenceItem *inference;
+} NativeRequestItem;
+
 #define OFFSET(x) offsetof(NativeContext, x)
 #define FLAGS AV_OPT_FLAG_FILTERING_PARAM
 static const AVOption dnn_native_options[] = {
@@ -47,6 +52,40 @@ static const AVClass dnn_native_class = {
 };
 
 static DNNReturnType execute_model_native(Queue *inference_queue);
+
+static DnnOperand* copy_operands(NativeModel *native_model)
+{
+    DnnOperand *original, *duplicate;
+
+    original = native_model->operands;
+    duplicate = av_mallocz(native_model->operands_num * sizeof(DnnOperand));
+    if (!duplicate) {
+        return NULL;
+    }
+
+    for (int32_t i = 0; i < native_model->operands_num; ++i){
+        DnnOperand *oprd, *src;
+
+        oprd = &duplicate[i];
+        src = &original[i];
+
+        oprd->data = NULL;
+        oprd->type = src->type;
+        oprd->length = src->length;
+        oprd->isNHWC = src->isNHWC;
+        oprd->data_type = src->data_type;
+        oprd->usedNumbersLeft = src->usedNumbersLeft;
+
+        for (int32_t dim = 0; dim < 4; ++dim) {
+            oprd->dims[dim] = src->dims[dim];
+        }
+
+        for (int32_t index = 0; index < 128; ++index) {
+            oprd->name[index] = src->name[index];
+        }
+    }
+    return duplicate;
+}
 
 static DNNReturnType extract_inference_from_task(TaskItem *task, Queue *inference_queue)
 {

--- a/libavfilter/dnn/dnn_backend_native.c
+++ b/libavfilter/dnn/dnn_backend_native.c
@@ -52,6 +52,7 @@ static const AVClass dnn_native_class = {
 };
 
 static DNNReturnType execute_model_native(NativeRequestItem *request, Queue *inference_queue);
+static void infer_completion_callback(void *args);
 
 static DnnOperand* copy_operands(NativeModel *native_model)
 {
@@ -85,6 +86,45 @@ static DnnOperand* copy_operands(NativeModel *native_model)
         }
     }
     return duplicate;
+}
+
+static void native_free_request(NativeRequestItem *request, int32_t numOperands)
+{
+    if (!request->operands)
+        return;
+
+    for (int32_t i = 0; i < numOperands; ++i){
+        av_freep(&request->operands[i].data);
+    }
+    av_freep(&request->operands);
+}
+
+static DNNReturnType native_start_inference(void *args)
+{
+    int32_t layer;
+    NativeRequestItem *request = args;
+    InferenceItem *inference = request->inference;
+    TaskItem *task = inference->task;
+    NativeModel *native_model = task->model;
+    NativeContext *ctx = &native_model->ctx;
+
+    if (!request) {
+        av_log(ctx, AV_LOG_ERROR, "NativeRequestItem is NULL\n");
+        return DNN_ERROR;
+    }
+
+    for (layer = 0; layer < native_model->layers_num; ++layer){
+        DNNLayerType layer_type = native_model->layers[layer].type;
+        if (ff_layer_funcs[layer_type].pf_exec(request->operands,
+                                            native_model->layers[layer].input_operand_indexes,
+                                            native_model->layers[layer].output_operand_index,
+                                            native_model->layers[layer].params,
+                                            &native_model->ctx) == DNN_ERROR) {
+            av_log(ctx, AV_LOG_ERROR, "Failed to execute model\n");
+            return DNN_ERROR;
+        }
+    }
+    return DNN_SUCCESS;
 }
 
 static DNNReturnType extract_inference_from_task(TaskItem *task, Queue *inference_queue)

--- a/libavfilter/dnn/dnn_backend_native.c
+++ b/libavfilter/dnn/dnn_backend_native.c
@@ -33,6 +33,7 @@
 typedef struct NativeRequestItem {
     DnnOperand *operands;
     InferenceItem *inference;
+    DNNAsyncExecModule exec_module;
 } NativeRequestItem;
 
 #define OFFSET(x) offsetof(NativeContext, x)
@@ -430,15 +431,10 @@ DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType f
 
     ctx->class = &dnn_native_class;
     model->options = options;
-    ctx->options.async = 0;
+    ctx->options.async = 1;
     if (av_opt_set_from_string(&native_model->ctx, model->options, NULL, "=", "&") < 0)
         goto fail;
     native_model->model = model;
-
-    if (ctx->options.async) {
-        av_log(ctx, AV_LOG_WARNING, "Async not supported. Rolling back to sync\n");
-        native_model->ctx.options.async = 0;
-    }
 
 #if !HAVE_PTHREAD_CANCEL
     if (ctx->options.conv2d_threads > 1){
@@ -543,6 +539,11 @@ DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType f
             av_freep(&item);
             goto fail;
         }
+        item->exec_module.start_inference = &native_start_inference;
+        item->exec_module.callback = &infer_completion_callback;
+        item->exec_module.args = item;
+        ff_init_async_attributes(&item->exec_module);
+
         if (ff_safe_queue_push_back(native_model->request_queue, item) < 0) {
             av_freep(&item->operands);
             av_freep(&item);
@@ -571,38 +572,38 @@ fail:
 static DNNReturnType execute_model_native(NativeRequestItem *request, Queue *inference_queue)
 {
     NativeModel *native_model = NULL;
-    NativeContext *ctx = NULL;
-    int32_t layer;
     InferenceItem *inference = NULL;
     TaskItem *task = NULL;
 
     inference = ff_queue_peek_front(inference_queue);
     if (!inference) {
         av_log(NULL, AV_LOG_ERROR, "Failed to get inference item\n");
-        return DNN_ERROR;
+        goto err;
     }
     task = inference->task;
     native_model = task->model;
-    ctx = &native_model->ctx;
 
     if (fill_model_input_native(native_model, request) != DNN_SUCCESS) {
-        return DNN_ERROR;
+        goto err;
     }
 
-    for (layer = 0; layer < native_model->layers_num; ++layer){
-        DNNLayerType layer_type = native_model->layers[layer].type;
-        if (ff_layer_funcs[layer_type].pf_exec(request->operands,
-                                            native_model->layers[layer].input_operand_indexes,
-                                            native_model->layers[layer].output_operand_index,
-                                            native_model->layers[layer].params,
-                                            &native_model->ctx) == DNN_ERROR) {
-            av_log(ctx, AV_LOG_ERROR, "Failed to execute model\n");
-            return DNN_ERROR;
+    if (task->async) {
+        return ff_dnn_start_inference_async(&native_model->ctx, &request->exec_module);
+    } else {
+        if (native_start_inference(request) != DNN_SUCCESS) {
+            goto err;
         }
-    }
-    infer_completion_callback(request);
+        infer_completion_callback(request);
 
-    return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_ERROR;
+        return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_ERROR;
+    }
+err:
+    native_free_request(request, native_model->operands_num);
+    if (ff_safe_queue_push_back(native_model->request_queue, request) < 0) {
+        ff_destroy_async_attributes(&request->exec_module);
+        av_freep(&request);
+    }
+    return DNN_ERROR;
 }
 
 DNNReturnType ff_dnn_execute_model_native(const DNNModel *model, DNNExecBaseParams *exec_params)
@@ -723,7 +724,8 @@ void ff_dnn_free_model_native(DNNModel **model)
 
             while (ff_safe_queue_size(native_model->request_queue) != 0) {
                 NativeRequestItem *item = ff_safe_queue_pop_front(native_model->request_queue);
-                av_freep(&item->operands);
+                native_free_request(item, native_model->operands_num);
+                ff_destroy_async_attributes(&item->exec_module);
                 av_freep(&item);
             }
             ff_safe_queue_destroy(native_model->request_queue);

--- a/libavfilter/dnn/dnn_backend_native.c
+++ b/libavfilter/dnn/dnn_backend_native.c
@@ -54,6 +54,13 @@ static const AVClass dnn_native_class = {
 static DNNReturnType execute_model_native(NativeRequestItem *request, Queue *inference_queue);
 static void infer_completion_callback(void *args);
 
+/**
+ * Copy operands from the Operands in the Native Model
+ *
+ * @param native_model pointer to the native backend model
+ * @return Pointer to the newly created copy of DnnOperands.
+ * @retval NULL if memory cannot be allocated.
+ */
 static DnnOperand* copy_operands(NativeModel *native_model)
 {
     DnnOperand *original, *duplicate;
@@ -88,6 +95,12 @@ static DnnOperand* copy_operands(NativeModel *native_model)
     return duplicate;
 }
 
+/**
+ * Free the operands and their data in the NativeRequestItem
+ *
+ * @param request pointer to the NativeRequestItem
+ * @param numOperands number of operands
+ */
 static void native_free_request(NativeRequestItem *request, int32_t numOperands)
 {
     if (!request->operands)
@@ -99,6 +112,14 @@ static void native_free_request(NativeRequestItem *request, int32_t numOperands)
     av_freep(&request->operands);
 }
 
+/**
+ * Start synchronous inference of the model
+ *
+ * @param args pointer to the NativeRequestItem for execution.
+ * Data should already be filled in the input operand.
+ * @retval DNN_SUCCESS on successful execution
+ * @retval DNN_ERROR if unable to execute the model
+ */
 static DNNReturnType native_start_inference(void *args)
 {
     int32_t layer;

--- a/libavfilter/dnn/dnn_backend_native.h
+++ b/libavfilter/dnn/dnn_backend_native.h
@@ -30,6 +30,7 @@
 #include "../dnn_interface.h"
 #include "libavformat/avio.h"
 #include "libavutil/opt.h"
+#include "safe_queue.h"
 #include "queue.h"
 
 /**
@@ -112,6 +113,7 @@ typedef struct InputParams{
 
 typedef struct NativeOptions{
     uint8_t async;
+    uint32_t nireq;
     uint32_t conv2d_threads;
 } NativeOptions;
 
@@ -130,6 +132,7 @@ typedef struct NativeModel{
     int32_t operands_num;
     Queue *task_queue;
     Queue *inference_queue;
+    SafeQueue *request_queue;
 } NativeModel;
 
 DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);

--- a/libavfilter/dnn/dnn_backend_native.h
+++ b/libavfilter/dnn/dnn_backend_native.h
@@ -30,6 +30,7 @@
 #include "../dnn_interface.h"
 #include "libavformat/avio.h"
 #include "libavutil/opt.h"
+#include "queue.h"
 
 /**
  * the enum value of DNNLayerType should not be changed,
@@ -110,6 +111,7 @@ typedef struct InputParams{
 } InputParams;
 
 typedef struct NativeOptions{
+    uint8_t async;
     uint32_t conv2d_threads;
 } NativeOptions;
 
@@ -126,11 +128,17 @@ typedef struct NativeModel{
     int32_t layers_num;
     DnnOperand *operands;
     int32_t operands_num;
+    Queue *task_queue;
+    Queue *inference_queue;
 } NativeModel;
 
 DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
 DNNReturnType ff_dnn_execute_model_native(const DNNModel *model, DNNExecBaseParams *exec_params);
+
+DNNAsyncStatusType ff_dnn_get_result_native(const DNNModel *model, AVFrame **in, AVFrame **out);
+
+DNNReturnType ff_dnn_flush_native(const DNNModel *model);
 
 void ff_dnn_free_model_native(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_backend_native_layer_conv2d.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_conv2d.c
@@ -188,10 +188,17 @@ int ff_dnn_execute_layer_conv2d(DnnOperand *operands, const int32_t *input_opera
                                 int32_t output_operand_index, const void *parameters, NativeContext *ctx)
 {
 #if HAVE_PTHREAD_CANCEL
-    int thread_num = (ctx->options.conv2d_threads <= 0 || ctx->options.conv2d_threads > av_cpu_count())
-        ? (av_cpu_count() + 1) : (ctx->options.conv2d_threads);
+    int thread_num;
     int ret = DNN_SUCCESS, thread_stride;
     ThreadParam *thread_param;
+    if (ctx->options.async) {
+        thread_num = (ctx->options.conv2d_threads <= 0 || ctx->options.conv2d_threads > av_cpu_count()/4+1)
+            ? (av_cpu_count()/4 + 1) : (ctx->options.conv2d_threads);
+    }
+    else {
+        thread_num = (ctx->options.conv2d_threads <= 0 || ctx->options.conv2d_threads > av_cpu_count())
+            ? (av_cpu_count() + 1) : (ctx->options.conv2d_threads);
+    }
 #else
     ThreadParam thread_param = { 0 };
 #endif

--- a/libavfilter/dnn/dnn_backend_openvino.c
+++ b/libavfilter/dnn/dnn_backend_openvino.c
@@ -32,7 +32,6 @@
 #include "libavutil/avstring.h"
 #include "libavutil/detection_bbox.h"
 #include "../internal.h"
-#include "queue.h"
 #include "safe_queue.h"
 #include <c_api/ie_c_api.h>
 #include "dnn_backend_common.h"
@@ -883,22 +882,7 @@ DNNReturnType ff_dnn_execute_model_async_ov(const DNNModel *model, DNNExecBasePa
 DNNAsyncStatusType ff_dnn_get_async_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out)
 {
     OVModel *ov_model = model->model;
-    TaskItem *task = ff_queue_peek_front(ov_model->task_queue);
-
-    if (!task) {
-        return DAST_EMPTY_QUEUE;
-    }
-
-    if (task->inference_done != task->inference_todo) {
-        return DAST_NOT_READY;
-    }
-
-    *in = task->in_frame;
-    *out = task->out_frame;
-    ff_queue_pop_front(ov_model->task_queue);
-    av_freep(&task);
-
-    return DAST_SUCCESS;
+    return dnn_get_async_result(ov_model->task_queue, in, out);
 }
 
 DNNReturnType ff_dnn_flush_ov(const DNNModel *model)

--- a/libavfilter/dnn/dnn_backend_openvino.c
+++ b/libavfilter/dnn/dnn_backend_openvino.c
@@ -640,10 +640,15 @@ static DNNReturnType get_output_ov(void *model, const char *input_name, int inpu
     OVContext *ctx = &ov_model->ctx;
     TaskItem task;
     OVRequestItem *request;
-    AVFrame *in_frame = NULL;
-    AVFrame *out_frame = NULL;
     IEStatusCode status;
     input_shapes_t input_shapes;
+    DNNExecBaseParams exec_params = {
+        .input_name     = input_name,
+        .output_names   = &output_name,
+        .nb_output      = 1,
+        .in_frame       = NULL,
+        .out_frame      = NULL,
+    };
 
     if (ov_model->model->func_type != DFT_PROCESS_FRAME) {
         av_log(ctx, AV_LOG_ERROR, "Get output dim only when processing frame.\n");
@@ -669,51 +674,29 @@ static DNNReturnType get_output_ov(void *model, const char *input_name, int inpu
         }
     }
 
-    in_frame = av_frame_alloc();
-    if (!in_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
+    if (dnn_get_output(&task, &exec_params, ov_model, input_height, input_width, ctx) != DNN_SUCCESS) {
         return DNN_ERROR;
     }
-    in_frame->width = input_width;
-    in_frame->height = input_height;
-
-    out_frame = av_frame_alloc();
-    if (!out_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
-        av_frame_free(&in_frame);
-        return DNN_ERROR;
-    }
-
-    task.do_ioproc = 0;
-    task.async = 0;
-    task.input_name = input_name;
-    task.in_frame = in_frame;
-    task.output_names = &output_name;
-    task.out_frame = out_frame;
-    task.nb_output = 1;
-    task.model = ov_model;
 
     if (extract_inference_from_task(ov_model->model->func_type, &task, ov_model->inference_queue, NULL) != DNN_SUCCESS) {
-        av_frame_free(&out_frame);
-        av_frame_free(&in_frame);
         av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
-        return DNN_ERROR;
+        ret = DNN_ERROR;
+        goto err;
     }
 
     request = ff_safe_queue_pop_front(ov_model->request_queue);
     if (!request) {
-        av_frame_free(&out_frame);
-        av_frame_free(&in_frame);
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-        return DNN_ERROR;
+        ret = DNN_ERROR;
+        goto err;
     }
 
     ret = execute_model_ov(request, ov_model->inference_queue);
-    *output_width = out_frame->width;
-    *output_height = out_frame->height;
-
-    av_frame_free(&out_frame);
-    av_frame_free(&in_frame);
+    *output_width = task.out_frame->width;
+    *output_height = task.out_frame->height;
+err:
+    av_frame_free(&task.out_frame);
+    av_frame_free(&task.in_frame);
     return ret;
 }
 

--- a/libavfilter/dnn/dnn_backend_openvino.h
+++ b/libavfilter/dnn/dnn_backend_openvino.h
@@ -32,8 +32,7 @@
 DNNModel *ff_dnn_load_model_ov(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
 DNNReturnType ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *exec_params);
-DNNReturnType ff_dnn_execute_model_async_ov(const DNNModel *model, DNNExecBaseParams *exec_params);
-DNNAsyncStatusType ff_dnn_get_async_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out);
+DNNAsyncStatusType ff_dnn_get_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out);
 DNNReturnType ff_dnn_flush_ov(const DNNModel *model);
 
 void ff_dnn_free_model_ov(DNNModel **model);

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -83,7 +83,6 @@ typedef struct TFRequestItem {
 #define FLAGS AV_OPT_FLAG_FILTERING_PARAM
 static const AVOption dnn_tensorflow_options[] = {
     { "sess_config", "config for SessionOptions", OFFSET(options.sess_config), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, FLAGS },
-    { "async",  "use DNN async inference",OFFSET(options.async), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, FLAGS},
     DNN_BACKEND_COMMON_OPTIONS
     { NULL }
 };

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -37,7 +37,6 @@
 #include "dnn_io_proc.h"
 #include "dnn_backend_common.h"
 #include "safe_queue.h"
-#include "queue.h"
 #include <tensorflow/c/c_api.h>
 
 typedef struct TFOptions{
@@ -58,6 +57,7 @@ typedef struct TFModel{
     TF_Status *status;
     SafeQueue *request_queue;
     Queue *inference_queue;
+    Queue *task_queue;
 } TFModel;
 
 /**
@@ -74,7 +74,7 @@ typedef struct TFInferRequest {
 typedef struct TFRequestItem {
     TFInferRequest *infer_request;
     InferenceItem *inference;
-    // further properties will be added later for async
+    DNNAsyncExecModule exec_module;
 } TFRequestItem;
 
 #define OFFSET(x) offsetof(TFContext, x)
@@ -88,6 +88,7 @@ static const AVOption dnn_tensorflow_options[] = {
 AVFILTER_DEFINE_CLASS(dnn_tensorflow);
 
 static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *inference_queue);
+static void infer_completion_callback(void *args);
 
 static void free_buffer(void *data, size_t length)
 {
@@ -885,6 +886,10 @@ DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_
             av_freep(&item);
             goto err;
         }
+        item->exec_module.start_inference = &tf_start_inference;
+        item->exec_module.callback = &infer_completion_callback;
+        item->exec_module.args = item;
+        ff_init_async_attributes(&item->exec_module);
 
         if (ff_safe_queue_push_back(tf_model->request_queue, item) < 0) {
             av_freep(&item->infer_request);
@@ -895,6 +900,11 @@ DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_
 
     tf_model->inference_queue = ff_queue_create();
     if (!tf_model->inference_queue) {
+        goto err;
+    }
+
+    tf_model->task_queue = ff_queue_create();
+    if (!tf_model->task_queue) {
         goto err;
     }
 
@@ -1060,7 +1070,6 @@ static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *inference_q
 {
     TFModel *tf_model;
     TFContext *ctx;
-    TFInferRequest *infer_request;
     InferenceItem *inference;
     TaskItem *task;
 
@@ -1073,23 +1082,14 @@ static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *inference_q
     tf_model = task->model;
     ctx = &tf_model->ctx;
 
-    if (task->async) {
-        avpriv_report_missing_feature(ctx, "Async execution not supported");
+    if (fill_model_input_tf(tf_model, request) != DNN_SUCCESS) {
         return DNN_ERROR;
-    } else {
-        if (fill_model_input_tf(tf_model, request) != DNN_SUCCESS) {
-            return DNN_ERROR;
-        }
+    }
 
-        infer_request = request->infer_request;
-        TF_SessionRun(tf_model->session, NULL,
-                      infer_request->tf_input, &infer_request->input_tensor, 1,
-                      infer_request->tf_outputs, infer_request->output_tensors,
-                      task->nb_output, NULL, 0, NULL,
-                      tf_model->status);
-        if (TF_GetCode(tf_model->status) != TF_OK) {
-            tf_free_request(infer_request);
-            av_log(ctx, AV_LOG_ERROR, "Failed to run session when executing model\n");
+    if (task->async) {
+        return ff_dnn_start_inference_async(ctx, &request->exec_module);
+    } else {
+        if (tf_start_inference(request) != DNN_SUCCESS) {
             return DNN_ERROR;
         }
         infer_completion_callback(request);
@@ -1126,6 +1126,83 @@ DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *
     return execute_model_tf(request, tf_model->inference_queue);
 }
 
+DNNReturnType ff_dnn_execute_model_async_tf(const DNNModel *model, DNNExecBaseParams *exec_params) {
+    TFModel *tf_model = model->model;
+    TFContext *ctx = &tf_model->ctx;
+    TaskItem *task;
+    TFRequestItem *request;
+
+    if (ff_check_exec_params(ctx, DNN_TF, model->func_type, exec_params) != 0) {
+        return DNN_ERROR;
+    }
+
+    task = av_malloc(sizeof(*task));
+    if (!task) {
+        av_log(ctx, AV_LOG_ERROR, "unable to alloc memory for task item.\n");
+        return DNN_ERROR;
+    }
+
+    if (ff_dnn_fill_task(task, exec_params, tf_model, 1, 1) != DNN_SUCCESS) {
+        av_freep(&task);
+        return DNN_ERROR;
+    }
+
+    if (ff_queue_push_back(tf_model->task_queue, task) < 0) {
+        av_freep(&task);
+        av_log(ctx, AV_LOG_ERROR, "unable to push back task_queue.\n");
+        return DNN_ERROR;
+    }
+
+    if (extract_inference_from_task(task, tf_model->inference_queue) != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
+        return DNN_ERROR;
+    }
+
+    request = ff_safe_queue_pop_front(tf_model->request_queue);
+    if (!request) {
+        av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
+        return DNN_ERROR;
+    }
+    return execute_model_tf(request, tf_model->inference_queue);
+}
+
+DNNAsyncStatusType ff_dnn_get_async_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out)
+{
+    TFModel *tf_model = model->model;
+    return dnn_get_async_result(tf_model->task_queue, in, out);
+}
+
+DNNReturnType ff_dnn_flush_tf(const DNNModel *model)
+{
+    TFModel *tf_model = model->model;
+    TFContext *ctx = &tf_model->ctx;
+    TFRequestItem *request;
+    DNNReturnType ret;
+
+    if (ff_queue_size(tf_model->inference_queue) == 0) {
+        // no pending task need to flush
+        return DNN_SUCCESS;
+    }
+
+    request = ff_safe_queue_pop_front(tf_model->request_queue);
+    if (!request) {
+        av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
+        return DNN_ERROR;
+    }
+
+    ret = fill_model_input_tf(tf_model, request);
+    if (ret != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "Failed to fill model input.\n");
+        if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
+            av_freep(&request->infer_request);
+            av_freep(&request);
+        }
+        return ret;
+    }
+
+    return ff_dnn_start_inference_async(ctx, &request->exec_module);
+}
+
 void ff_dnn_free_model_tf(DNNModel **model)
 {
     TFModel *tf_model;
@@ -1134,6 +1211,7 @@ void ff_dnn_free_model_tf(DNNModel **model)
         tf_model = (*model)->model;
         while (ff_safe_queue_size(tf_model->request_queue) != 0) {
             TFRequestItem *item = ff_safe_queue_pop_front(tf_model->request_queue);
+            ff_destroy_async_attributes(&item->exec_module);
             tf_free_request(item->infer_request);
             av_freep(&item->infer_request);
             av_freep(&item);
@@ -1145,6 +1223,14 @@ void ff_dnn_free_model_tf(DNNModel **model)
             av_freep(&item);
         }
         ff_queue_destroy(tf_model->inference_queue);
+
+        while (ff_queue_size(tf_model->task_queue) != 0) {
+            TaskItem *item = ff_queue_pop_front(tf_model->task_queue);
+            av_frame_free(&item->in_frame);
+            av_frame_free(&item->out_frame);
+            av_freep(&item);
+        }
+        ff_queue_destroy(tf_model->task_queue);
 
         if (tf_model->graph){
             TF_DeleteGraph(tf_model->graph);

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -309,35 +309,19 @@ static DNNReturnType get_output_tf(void *model, const char *input_name, int inpu
     DNNReturnType ret;
     TFModel *tf_model = model;
     TFContext *ctx = &tf_model->ctx;
-    AVFrame *in_frame = av_frame_alloc();
-    AVFrame *out_frame = NULL;
     TaskItem task;
     TFRequestItem *request;
+    DNNExecBaseParams exec_params = {
+        .input_name     = input_name,
+        .output_names   = &output_name,
+        .nb_output      = 1,
+        .in_frame       = NULL,
+        .out_frame      = NULL,
+    };
 
-    if (!in_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
-        ret = DNN_ERROR;
+    if (dnn_get_output(&task, &exec_params, tf_model, input_height, input_width, ctx) != DNN_SUCCESS) {
         goto err;
     }
-
-    out_frame = av_frame_alloc();
-    if (!out_frame) {
-        av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
-        ret = DNN_ERROR;
-        goto err;
-    }
-
-    in_frame->width = input_width;
-    in_frame->height = input_height;
-
-    task.do_ioproc = 0;
-    task.async = 0;
-    task.input_name = input_name;
-    task.in_frame = in_frame;
-    task.output_names = &output_name;
-    task.out_frame = out_frame;
-    task.model = tf_model;
-    task.nb_output = 1;
 
     if (extract_inference_from_task(&task, tf_model->inference_queue) != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
@@ -353,12 +337,12 @@ static DNNReturnType get_output_tf(void *model, const char *input_name, int inpu
     }
 
     ret = execute_model_tf(request, tf_model->inference_queue);
-    *output_width = out_frame->width;
-    *output_height = out_frame->height;
+    *output_width = task.out_frame->width;
+    *output_height = task.out_frame->height;
 
 err:
-    av_frame_free(&out_frame);
-    av_frame_free(&in_frame);
+    av_frame_free(&task.out_frame);
+    av_frame_free(&task.in_frame);
     return ret;
 }
 

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -172,6 +172,24 @@ static DNNReturnType tf_start_inference(void *args)
     return DNN_SUCCESS;
 }
 
+/**
+ * Free the TFRequestItem completely.
+ *
+ * @param arg Address of the TFInferRequest instance.
+ */
+static inline void delete_request_item(TFRequestItem **arg) {
+    TFRequestItem *request;
+    if (!arg) {
+        return;
+    }
+    request = *arg;
+    tf_free_request(request->infer_request);
+    av_freep(&request->infer_request);
+    av_freep(&request->inference);
+    ff_destroy_async_attributes(&request->exec_module);
+    av_freep(arg);
+}
+
 static DNNReturnType extract_inference_from_task(TaskItem *task, Queue *inference_queue)
 {
     TFModel *tf_model = task->model;
@@ -880,6 +898,7 @@ DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_
         if (!item) {
             goto err;
         }
+        item->inference = NULL;
         item->infer_request = tf_create_inference_request();
         if (!item->infer_request) {
             av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for TensorFlow inference request\n");
@@ -892,8 +911,7 @@ DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_
         ff_init_async_attributes(&item->exec_module);
 
         if (ff_safe_queue_push_back(tf_model->request_queue, item) < 0) {
-            av_freep(&item->infer_request);
-            av_freep(&item);
+            delete_request_item(&item);
             goto err;
         }
     }
@@ -1060,8 +1078,7 @@ err:
     av_freep(&outputs);
 
     if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
-        av_freep(&request->infer_request);
-        av_freep(&request);
+        delete_request_item(&request);
         av_log(ctx, AV_LOG_ERROR, "Failed to push back request_queue.\n");
     }
 }
@@ -1073,28 +1090,35 @@ static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *inference_q
     InferenceItem *inference;
     TaskItem *task;
 
-    inference = ff_queue_peek_front(inference_queue);
-    if (!inference) {
-        av_log(NULL, AV_LOG_ERROR, "Failed to get inference item\n");
-        return DNN_ERROR;
+    if (ff_queue_size(inference_queue) == 0) {
+        delete_request_item(&request);
+        return DNN_SUCCESS;
     }
+
+    inference = ff_queue_peek_front(inference_queue);
     task = inference->task;
     tf_model = task->model;
     ctx = &tf_model->ctx;
 
     if (fill_model_input_tf(tf_model, request) != DNN_SUCCESS) {
-        return DNN_ERROR;
+        goto err;
     }
 
     if (task->async) {
         return ff_dnn_start_inference_async(ctx, &request->exec_module);
     } else {
         if (tf_start_inference(request) != DNN_SUCCESS) {
-            return DNN_ERROR;
+            goto err;
         }
         infer_completion_callback(request);
         return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_ERROR;
     }
+err:
+    tf_free_request(request->infer_request);
+    if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
+        delete_request_item(&request);
+    }
+    return DNN_ERROR;
 }
 
 DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params)
@@ -1194,8 +1218,7 @@ DNNReturnType ff_dnn_flush_tf(const DNNModel *model)
     if (ret != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "Failed to fill model input.\n");
         if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
-            av_freep(&request->infer_request);
-            av_freep(&request);
+            delete_request_item(&request);
         }
         return ret;
     }
@@ -1211,10 +1234,7 @@ void ff_dnn_free_model_tf(DNNModel **model)
         tf_model = (*model)->model;
         while (ff_safe_queue_size(tf_model->request_queue) != 0) {
             TFRequestItem *item = ff_safe_queue_pop_front(tf_model->request_queue);
-            ff_destroy_async_attributes(&item->exec_module);
-            tf_free_request(item->infer_request);
-            av_freep(&item->infer_request);
-            av_freep(&item);
+            delete_request_item(&item);
         }
         ff_safe_queue_destroy(tf_model->request_queue);
 

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -74,6 +74,7 @@ typedef struct TFInferRequest {
 typedef struct TFRequestItem {
     TFInferRequest *infer_request;
     InferenceItem *inference;
+    TF_Status *status;
     DNNAsyncExecModule exec_module;
 } TFRequestItem;
 
@@ -164,8 +165,8 @@ static DNNReturnType tf_start_inference(void *args)
                   infer_request->tf_input, &infer_request->input_tensor, 1,
                   infer_request->tf_outputs, infer_request->output_tensors,
                   task->nb_output, NULL, 0, NULL,
-                  tf_model->status);
-    if (TF_GetCode(tf_model->status) != TF_OK) {
+                  request->status);
+    if (TF_GetCode(request->status) != TF_OK) {
         av_log(&tf_model->ctx, AV_LOG_ERROR, "Failed to run session when executing model\n");
         return DNN_ERROR;
     }
@@ -186,6 +187,7 @@ static inline void delete_request_item(TFRequestItem **arg) {
     tf_free_request(request->infer_request);
     av_freep(&request->infer_request);
     av_freep(&request->inference);
+    TF_DeleteStatus(request->status);
     ff_destroy_async_attributes(&request->exec_module);
     av_freep(arg);
 }
@@ -905,6 +907,7 @@ DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_
             av_freep(&item);
             goto err;
         }
+        item->status = TF_NewStatus();
         item->exec_module.start_inference = &tf_start_inference;
         item->exec_module.callback = &infer_completion_callback;
         item->exec_module.args = item;

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -94,6 +94,13 @@ static void free_buffer(void *data, size_t length)
     av_freep(&data);
 }
 
+/**
+ * Free the contents of TensorFlow inference request.
+ * It does not free the TFInferRequest instance.
+ *
+ * @param request pointer to TFInferRequest instance.
+ * NULL pointer is allowed.
+ */
 static void tf_free_request(TFInferRequest *request)
 {
     if (!request)
@@ -116,6 +123,12 @@ static void tf_free_request(TFInferRequest *request)
     }
 }
 
+/**
+ * Create a TensorFlow inference request. All properties
+ * are initially unallocated and set as NULL.
+ *
+ * @return pointer to the allocated TFInferRequest instance.
+ */
 static TFInferRequest *tf_create_inference_request(void)
 {
     TFInferRequest *infer_request = av_malloc(sizeof(TFInferRequest));
@@ -124,6 +137,38 @@ static TFInferRequest *tf_create_inference_request(void)
     infer_request->input_tensor = NULL;
     infer_request->output_tensors = NULL;
     return infer_request;
+}
+
+/**
+ * Start synchronous inference for the TensorFlow model.
+ *
+ * @param request pointer to the TFRequestItem for inference
+ * @retval DNN_SUCCESS if execution is successful
+ * @retval DNN_ERROR if execution fails
+ */
+static DNNReturnType tf_start_inference(void *args)
+{
+    TFRequestItem *request = args;
+    TFInferRequest *infer_request = request->infer_request;
+    InferenceItem *inference = request->inference;
+    TaskItem *task = inference->task;
+    TFModel *tf_model = task->model;
+
+    if (!request) {
+        av_log(&tf_model->ctx, AV_LOG_ERROR, "TFRequestItem is NULL\n");
+        return DNN_ERROR;
+    }
+
+    TF_SessionRun(tf_model->session, NULL,
+                  infer_request->tf_input, &infer_request->input_tensor, 1,
+                  infer_request->tf_outputs, infer_request->output_tensors,
+                  task->nb_output, NULL, 0, NULL,
+                  tf_model->status);
+    if (TF_GetCode(tf_model->status) != TF_OK) {
+        av_log(&tf_model->ctx, AV_LOG_ERROR, "Failed to run session when executing model\n");
+        return DNN_ERROR;
+    }
+    return DNN_SUCCESS;
 }
 
 static DNNReturnType extract_inference_from_task(TaskItem *task, Queue *inference_queue)

--- a/libavfilter/dnn/dnn_backend_tf.h
+++ b/libavfilter/dnn/dnn_backend_tf.h
@@ -32,8 +32,7 @@
 DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
 DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
-DNNReturnType ff_dnn_execute_model_async_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
-DNNAsyncStatusType ff_dnn_get_async_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out);
+DNNAsyncStatusType ff_dnn_get_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out);
 DNNReturnType ff_dnn_flush_tf(const DNNModel *model);
 
 void ff_dnn_free_model_tf(DNNModel **model);

--- a/libavfilter/dnn/dnn_backend_tf.h
+++ b/libavfilter/dnn/dnn_backend_tf.h
@@ -32,6 +32,9 @@
 DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
 DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
+DNNReturnType ff_dnn_execute_model_async_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
+DNNAsyncStatusType ff_dnn_get_async_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out);
+DNNReturnType ff_dnn_flush_tf(const DNNModel *model);
 
 void ff_dnn_free_model_tf(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -48,6 +48,9 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
     #if (CONFIG_LIBTENSORFLOW == 1)
         dnn_module->load_model = &ff_dnn_load_model_tf;
         dnn_module->execute_model = &ff_dnn_execute_model_tf;
+        dnn_module->execute_model_async = &ff_dnn_execute_model_async_tf;
+        dnn_module->get_async_result = &ff_dnn_get_async_result_tf;
+        dnn_module->flush = &ff_dnn_flush_tf;
         dnn_module->free_model = &ff_dnn_free_model_tf;
     #else
         av_freep(&dnn_module);

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -61,13 +61,9 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
         break;
     case DNN_OV:
     #if (CONFIG_LIBOPENVINO == 1)
-        // for now OpenVino backend isn't unified
-        av_freep(&dnn_module);
-        return NULL;
         dnn_module->load_model = &ff_dnn_load_model_ov;
         dnn_module->execute_model = &ff_dnn_execute_model_ov;
-        // dnn_module->execute_model_async = &ff_dnn_execute_model_async_ov;
-        // dnn_module->get_result = &ff_dnn_get_async_result_ov;
+        dnn_module->get_result = &ff_dnn_get_result_ov;
         dnn_module->flush = &ff_dnn_flush_ov;
         dnn_module->free_model = &ff_dnn_free_model_ov;
     #else

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -33,10 +33,6 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
 {
     DNNModule *dnn_module;
 
-    // temporary change till unification completes in atleast one backend
-    av_log(NULL, AV_LOG_ERROR, "Execution currently not supported \n");
-    return NULL;
-
     dnn_module = av_mallocz(sizeof(DNNModule));
     if(!dnn_module){
         return NULL;
@@ -44,6 +40,9 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
 
     switch(backend_type){
     case DNN_NATIVE:
+        // for now Native backend isn't unified
+        av_freep(&dnn_module);
+        return NULL;
         dnn_module->load_model = &ff_dnn_load_model_native;
         dnn_module->execute_model = &ff_dnn_execute_model_native;
         dnn_module->free_model = &ff_dnn_free_model_native;
@@ -52,8 +51,7 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
     #if (CONFIG_LIBTENSORFLOW == 1)
         dnn_module->load_model = &ff_dnn_load_model_tf;
         dnn_module->execute_model = &ff_dnn_execute_model_tf;
-        // dnn_module->execute_model_async = &ff_dnn_execute_model_async_tf;
-        // dnn_module->get_result = &ff_dnn_get_async_result_tf;
+        dnn_module->get_result = &ff_dnn_get_result_tf;
         dnn_module->flush = &ff_dnn_flush_tf;
         dnn_module->free_model = &ff_dnn_free_model_tf;
     #else
@@ -63,6 +61,9 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
         break;
     case DNN_OV:
     #if (CONFIG_LIBOPENVINO == 1)
+        // for now OpenVino backend isn't unified
+        av_freep(&dnn_module);
+        return NULL;
         dnn_module->load_model = &ff_dnn_load_model_ov;
         dnn_module->execute_model = &ff_dnn_execute_model_ov;
         // dnn_module->execute_model_async = &ff_dnn_execute_model_async_ov;

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -40,11 +40,10 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
 
     switch(backend_type){
     case DNN_NATIVE:
-        // for now Native backend isn't unified
-        av_freep(&dnn_module);
-        return NULL;
         dnn_module->load_model = &ff_dnn_load_model_native;
         dnn_module->execute_model = &ff_dnn_execute_model_native;
+        dnn_module->get_result = &ff_dnn_get_result_native;
+        dnn_module->flush = &ff_dnn_flush_native;
         dnn_module->free_model = &ff_dnn_free_model_native;
         break;
     case DNN_TF:

--- a/libavfilter/dnn/dnn_interface.c
+++ b/libavfilter/dnn/dnn_interface.c
@@ -33,6 +33,10 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
 {
     DNNModule *dnn_module;
 
+    // temporary change till unification completes in atleast one backend
+    av_log(NULL, AV_LOG_ERROR, "Execution currently not supported \n");
+    return NULL;
+
     dnn_module = av_mallocz(sizeof(DNNModule));
     if(!dnn_module){
         return NULL;
@@ -48,8 +52,8 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
     #if (CONFIG_LIBTENSORFLOW == 1)
         dnn_module->load_model = &ff_dnn_load_model_tf;
         dnn_module->execute_model = &ff_dnn_execute_model_tf;
-        dnn_module->execute_model_async = &ff_dnn_execute_model_async_tf;
-        dnn_module->get_async_result = &ff_dnn_get_async_result_tf;
+        // dnn_module->execute_model_async = &ff_dnn_execute_model_async_tf;
+        // dnn_module->get_result = &ff_dnn_get_async_result_tf;
         dnn_module->flush = &ff_dnn_flush_tf;
         dnn_module->free_model = &ff_dnn_free_model_tf;
     #else
@@ -61,8 +65,8 @@ DNNModule *ff_get_dnn_module(DNNBackendType backend_type)
     #if (CONFIG_LIBOPENVINO == 1)
         dnn_module->load_model = &ff_dnn_load_model_ov;
         dnn_module->execute_model = &ff_dnn_execute_model_ov;
-        dnn_module->execute_model_async = &ff_dnn_execute_model_async_ov;
-        dnn_module->get_async_result = &ff_dnn_get_async_result_ov;
+        // dnn_module->execute_model_async = &ff_dnn_execute_model_async_ov;
+        // dnn_module->get_result = &ff_dnn_get_async_result_ov;
         dnn_module->flush = &ff_dnn_flush_ov;
         dnn_module->free_model = &ff_dnn_free_model_ov;
     #else

--- a/libavfilter/dnn/queue.h
+++ b/libavfilter/dnn/queue.h
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stddef.h>
 
 #ifndef AVFILTER_DNN_QUEUE_H
 #define AVFILTER_DNN_QUEUE_H

--- a/libavfilter/dnn_filter_common.c
+++ b/libavfilter/dnn_filter_common.c
@@ -84,13 +84,6 @@ int ff_dnn_init(DnnContext *ctx, DNNFunctionType func_type, AVFilterContext *fil
         return AVERROR(EINVAL);
     }
 
-#if !HAVE_PTHREAD_CANCEL
-    if (ctx->async) {
-        ctx->async = 0;
-        av_log(filter_ctx, AV_LOG_WARNING, "pthread is not supported, roll back to sync.\n");
-    }
-#endif
-
     return 0;
 }
 

--- a/libavfilter/dnn_filter_common.c
+++ b/libavfilter/dnn_filter_common.c
@@ -84,11 +84,6 @@ int ff_dnn_init(DnnContext *ctx, DNNFunctionType func_type, AVFilterContext *fil
         return AVERROR(EINVAL);
     }
 
-    if (!ctx->dnn_module->execute_model_async && ctx->async) {
-        ctx->async = 0;
-        av_log(filter_ctx, AV_LOG_WARNING, "this backend does not support async execution, roll back to sync.\n");
-    }
-
 #if !HAVE_PTHREAD_CANCEL
     if (ctx->async) {
         ctx->async = 0;
@@ -141,18 +136,6 @@ DNNReturnType ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *
     return (ctx->dnn_module->execute_model)(ctx->model, &exec_params);
 }
 
-DNNReturnType ff_dnn_execute_model_async(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame)
-{
-    DNNExecBaseParams exec_params = {
-        .input_name     = ctx->model_inputname,
-        .output_names   = (const char **)ctx->model_outputnames,
-        .nb_output      = ctx->nb_outputs,
-        .in_frame       = in_frame,
-        .out_frame      = out_frame,
-    };
-    return (ctx->dnn_module->execute_model_async)(ctx->model, &exec_params);
-}
-
 DNNReturnType ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target)
 {
     DNNExecClassificationParams class_params = {
@@ -165,12 +148,12 @@ DNNReturnType ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_f
         },
         .target = target,
     };
-    return (ctx->dnn_module->execute_model_async)(ctx->model, &class_params.base);
+    return (ctx->dnn_module->execute_model)(ctx->model, &class_params.base);
 }
 
-DNNAsyncStatusType ff_dnn_get_async_result(DnnContext *ctx, AVFrame **in_frame, AVFrame **out_frame)
+DNNAsyncStatusType ff_dnn_get_result(DnnContext *ctx, AVFrame **in_frame, AVFrame **out_frame)
 {
-    return (ctx->dnn_module->get_async_result)(ctx->model, in_frame, out_frame);
+    return (ctx->dnn_module->get_result)(ctx->model, in_frame, out_frame);
 }
 
 DNNReturnType ff_dnn_flush(DnnContext *ctx)

--- a/libavfilter/dnn_filter_common.h
+++ b/libavfilter/dnn_filter_common.h
@@ -56,9 +56,8 @@ int ff_dnn_set_classify_post_proc(DnnContext *ctx, ClassifyPostProc post_proc);
 DNNReturnType ff_dnn_get_input(DnnContext *ctx, DNNData *input);
 DNNReturnType ff_dnn_get_output(DnnContext *ctx, int input_width, int input_height, int *output_width, int *output_height);
 DNNReturnType ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame);
-DNNReturnType ff_dnn_execute_model_async(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame);
 DNNReturnType ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target);
-DNNAsyncStatusType ff_dnn_get_async_result(DnnContext *ctx, AVFrame **in_frame, AVFrame **out_frame);
+DNNAsyncStatusType ff_dnn_get_result(DnnContext *ctx, AVFrame **in_frame, AVFrame **out_frame);
 DNNReturnType ff_dnn_flush(DnnContext *ctx);
 void ff_dnn_uninit(DnnContext *ctx);
 

--- a/libavfilter/dnn_filter_common.h
+++ b/libavfilter/dnn_filter_common.h
@@ -32,7 +32,6 @@ typedef struct DnnContext {
     char *model_inputname;
     char *model_outputnames_string;
     char *backend_options;
-    int async;
 
     char **model_outputnames;
     uint32_t nb_outputs;
@@ -46,7 +45,6 @@ typedef struct DnnContext {
     { "output",             "output name of the model",   OFFSET(model_outputnames_string), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, FLAGS },\
     { "backend_configs",    "backend configs",            OFFSET(backend_options),  AV_OPT_TYPE_STRING,    { .str = NULL }, 0, 0, FLAGS },\
     { "options", "backend configs (deprecated, use backend_configs)", OFFSET(backend_options),  AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, FLAGS | AV_OPT_FLAG_DEPRECATED},\
-    { "async",              "use DNN async inference",    OFFSET(async),            AV_OPT_TYPE_BOOL,      { .i64 = 1},     0, 1, FLAGS},
 
 
 int ff_dnn_init(DnnContext *ctx, DNNFunctionType func_type, AVFilterContext *filter_ctx);

--- a/libavfilter/dnn_interface.h
+++ b/libavfilter/dnn_interface.h
@@ -114,10 +114,8 @@ typedef struct DNNModule{
     DNNModel *(*load_model)(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
     // Executes model with specified input and output. Returns DNN_ERROR otherwise.
     DNNReturnType (*execute_model)(const DNNModel *model, DNNExecBaseParams *exec_params);
-    // Executes model with specified input and output asynchronously. Returns DNN_ERROR otherwise.
-    DNNReturnType (*execute_model_async)(const DNNModel *model, DNNExecBaseParams *exec_params);
     // Retrieve inference result.
-    DNNAsyncStatusType (*get_async_result)(const DNNModel *model, AVFrame **in, AVFrame **out);
+    DNNAsyncStatusType (*get_result)(const DNNModel *model, AVFrame **in, AVFrame **out);
     // Flush all the pending tasks.
     DNNReturnType (*flush)(const DNNModel *model);
     // Frees memory allocated for model.

--- a/libavfilter/vf_dnn_classify.c
+++ b/libavfilter/vf_dnn_classify.c
@@ -225,7 +225,7 @@ static int dnn_classify_flush_frame(AVFilterLink *outlink, int64_t pts, int64_t 
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             av_assert0(in_frame == out_frame);
             ret = ff_filter_frame(outlink, out_frame);
@@ -269,7 +269,7 @@ static int dnn_classify_activate(AVFilterContext *filter_ctx)
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             av_assert0(in_frame == out_frame);
             ret = ff_filter_frame(outlink, out_frame);

--- a/libavfilter/vf_dnn_detect.c
+++ b/libavfilter/vf_dnn_detect.c
@@ -354,63 +354,6 @@ static int dnn_detect_query_formats(AVFilterContext *context)
     return ff_set_common_formats(context, fmts_list);
 }
 
-static int dnn_detect_filter_frame(AVFilterLink *inlink, AVFrame *in)
-{
-    AVFilterContext *context  = inlink->dst;
-    AVFilterLink *outlink = context->outputs[0];
-    DnnDetectContext *ctx = context->priv;
-    DNNReturnType dnn_result;
-
-    dnn_result = ff_dnn_execute_model(&ctx->dnnctx, in, in);
-    if (dnn_result != DNN_SUCCESS){
-        av_log(ctx, AV_LOG_ERROR, "failed to execute model\n");
-        av_frame_free(&in);
-        return AVERROR(EIO);
-    }
-
-    return ff_filter_frame(outlink, in);
-}
-
-static int dnn_detect_activate_sync(AVFilterContext *filter_ctx)
-{
-    AVFilterLink *inlink = filter_ctx->inputs[0];
-    AVFilterLink *outlink = filter_ctx->outputs[0];
-    AVFrame *in = NULL;
-    int64_t pts;
-    int ret, status;
-    int got_frame = 0;
-
-    FF_FILTER_FORWARD_STATUS_BACK(outlink, inlink);
-
-    do {
-        // drain all input frames
-        ret = ff_inlink_consume_frame(inlink, &in);
-        if (ret < 0)
-            return ret;
-        if (ret > 0) {
-            ret = dnn_detect_filter_frame(inlink, in);
-            if (ret < 0)
-                return ret;
-            got_frame = 1;
-        }
-    } while (ret > 0);
-
-    // if frame got, schedule to next filter
-    if (got_frame)
-        return 0;
-
-    if (ff_inlink_acknowledge_status(inlink, &status, &pts)) {
-        if (status == AVERROR_EOF) {
-            ff_outlink_set_status(outlink, status, pts);
-            return ret;
-        }
-    }
-
-    FF_FILTER_FORWARD_WANTED(outlink, inlink);
-
-    return FFERROR_NOT_READY;
-}
-
 static int dnn_detect_flush_frame(AVFilterLink *outlink, int64_t pts, int64_t *out_pts)
 {
     DnnDetectContext *ctx = outlink->src->priv;
@@ -425,7 +368,7 @@ static int dnn_detect_flush_frame(AVFilterLink *outlink, int64_t pts, int64_t *o
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             av_assert0(in_frame == out_frame);
             ret = ff_filter_frame(outlink, out_frame);
@@ -459,7 +402,7 @@ static int dnn_detect_activate_async(AVFilterContext *filter_ctx)
         if (ret < 0)
             return ret;
         if (ret > 0) {
-            if (ff_dnn_execute_model_async(&ctx->dnnctx, in, in) != DNN_SUCCESS) {
+            if (ff_dnn_execute_model(&ctx->dnnctx, in, in) != DNN_SUCCESS) {
                 return AVERROR(EIO);
             }
         }
@@ -469,7 +412,7 @@ static int dnn_detect_activate_async(AVFilterContext *filter_ctx)
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             av_assert0(in_frame == out_frame);
             ret = ff_filter_frame(outlink, out_frame);
@@ -499,12 +442,7 @@ static int dnn_detect_activate_async(AVFilterContext *filter_ctx)
 
 static int dnn_detect_activate(AVFilterContext *filter_ctx)
 {
-    DnnDetectContext *ctx = filter_ctx->priv;
-
-    if (ctx->dnnctx.async)
-        return dnn_detect_activate_async(filter_ctx);
-    else
-        return dnn_detect_activate_sync(filter_ctx);
+    return dnn_detect_activate_async(filter_ctx);
 }
 
 static av_cold void dnn_detect_uninit(AVFilterContext *context)

--- a/libavfilter/vf_dnn_processing.c
+++ b/libavfilter/vf_dnn_processing.c
@@ -245,76 +245,6 @@ static int copy_uv_planes(DnnProcessingContext *ctx, AVFrame *out, const AVFrame
     return 0;
 }
 
-static int filter_frame(AVFilterLink *inlink, AVFrame *in)
-{
-    AVFilterContext *context  = inlink->dst;
-    AVFilterLink *outlink = context->outputs[0];
-    DnnProcessingContext *ctx = context->priv;
-    DNNReturnType dnn_result;
-    AVFrame *out;
-
-    out = ff_get_video_buffer(outlink, outlink->w, outlink->h);
-    if (!out) {
-        av_frame_free(&in);
-        return AVERROR(ENOMEM);
-    }
-    av_frame_copy_props(out, in);
-
-    dnn_result = ff_dnn_execute_model(&ctx->dnnctx, in, out);
-    if (dnn_result != DNN_SUCCESS){
-        av_log(ctx, AV_LOG_ERROR, "failed to execute model\n");
-        av_frame_free(&in);
-        av_frame_free(&out);
-        return AVERROR(EIO);
-    }
-
-    if (isPlanarYUV(in->format))
-        copy_uv_planes(ctx, out, in);
-
-    av_frame_free(&in);
-    return ff_filter_frame(outlink, out);
-}
-
-static int activate_sync(AVFilterContext *filter_ctx)
-{
-    AVFilterLink *inlink = filter_ctx->inputs[0];
-    AVFilterLink *outlink = filter_ctx->outputs[0];
-    AVFrame *in = NULL;
-    int64_t pts;
-    int ret, status;
-    int got_frame = 0;
-
-    FF_FILTER_FORWARD_STATUS_BACK(outlink, inlink);
-
-    do {
-        // drain all input frames
-        ret = ff_inlink_consume_frame(inlink, &in);
-        if (ret < 0)
-            return ret;
-        if (ret > 0) {
-            ret = filter_frame(inlink, in);
-            if (ret < 0)
-                return ret;
-            got_frame = 1;
-        }
-    } while (ret > 0);
-
-    // if frame got, schedule to next filter
-    if (got_frame)
-        return 0;
-
-    if (ff_inlink_acknowledge_status(inlink, &status, &pts)) {
-        if (status == AVERROR_EOF) {
-            ff_outlink_set_status(outlink, status, pts);
-            return ret;
-        }
-    }
-
-    FF_FILTER_FORWARD_WANTED(outlink, inlink);
-
-    return FFERROR_NOT_READY;
-}
-
 static int flush_frame(AVFilterLink *outlink, int64_t pts, int64_t *out_pts)
 {
     DnnProcessingContext *ctx = outlink->src->priv;
@@ -329,7 +259,7 @@ static int flush_frame(AVFilterLink *outlink, int64_t pts, int64_t *out_pts)
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             if (isPlanarYUV(in_frame->format))
                 copy_uv_planes(ctx, out_frame, in_frame);
@@ -371,7 +301,7 @@ static int activate_async(AVFilterContext *filter_ctx)
                 return AVERROR(ENOMEM);
             }
             av_frame_copy_props(out, in);
-            if (ff_dnn_execute_model_async(&ctx->dnnctx, in, out) != DNN_SUCCESS) {
+            if (ff_dnn_execute_model(&ctx->dnnctx, in, out) != DNN_SUCCESS) {
                 return AVERROR(EIO);
             }
         }
@@ -381,7 +311,7 @@ static int activate_async(AVFilterContext *filter_ctx)
     do {
         AVFrame *in_frame = NULL;
         AVFrame *out_frame = NULL;
-        async_state = ff_dnn_get_async_result(&ctx->dnnctx, &in_frame, &out_frame);
+        async_state = ff_dnn_get_result(&ctx->dnnctx, &in_frame, &out_frame);
         if (out_frame) {
             if (isPlanarYUV(in_frame->format))
                 copy_uv_planes(ctx, out_frame, in_frame);
@@ -413,12 +343,7 @@ static int activate_async(AVFilterContext *filter_ctx)
 
 static int activate(AVFilterContext *filter_ctx)
 {
-    DnnProcessingContext *ctx = filter_ctx->priv;
-
-    if (ctx->dnnctx.async)
-        return activate_async(filter_ctx);
-    else
-        return activate_sync(filter_ctx);
+    return activate_async(filter_ctx);
 }
 
 static av_cold void uninit(AVFilterContext *ctx)


### PR DESCRIPTION
## TODO

This pull request will be reopened after the pull request #423 gets merged.

## Patch Set Description

This patchset is a part of optional deliverables in the GSoC project [Async Support for TensorFlow Backend in FFmpeg](https://summerofcode.withgoogle.com/projects/#5224576843251712).

- Builds on the patchset from PR #423. 

**Objective**: Extend the asynchronous inference support to the Native Backend.

### Parts under this deliverable

- Switches the inference mechanism to `NativeRequestItem` based.
- Extends the async support to the Native Backend

Notable Points

- Each `NativeRequestItem` has its own set of operands compared to a single operand set per `NativeModel` earlier.
- Reduced default value of `conv2d_threads` only for async execution

## Patches

1f177d1208b0ade875dfd6596408924372cfbcf2 lavfi/dnn_backend_native: Separate Functions for Filling Model with Input
2200a04cf33df661efa9f0069a1d775b2962c8f1 lavfi/dnn_backend_native: Separate Functions Completion Callback
848a8200ffdac47a8d570e86f2dd9597407b4d6b lavfi/dnn_backend_native: Add NativeRequestItem and copy_operands
d70712a6cf37d23fb14e0f49f1f29eb6cd999346 lavfi/dnn_backend_native: Request-based Inference
05f28d848c1ab6ae64e04f352259dff6ad3c8a06 lavfi/dnn_backend_native: Add Inference Function
e42c7295a48ad12be0313b56c1ef70baa8b9bd6b lavfi/dnn_backend_native: Documentation for New Functions
5431d81a8d68e151ccfc68f4d0d603bbcd884865 lavfi/dnn: Async Support for Native Backend
bf69c639c4dcf56e6e6c692cbc9ff1e9f796d4cf lavfi/dnn_backend_native: Switch Flushing to Async
1fb16f6ba9523c6369fe5db9516788cd6b13bd7c lavfi/dnn_backend_native: Reduce default value of conv2d_threads
