### PR TITLE
AVX512 Optimization for filters of hflip and threshold

### DIFF
--- a/libavfilter/vf_avgblur_vulkan.c
+++ b/libavfilter/vf_avgblur_vulkan.c
@@ -333,7 +333,7 @@ static int avgblur_vulkan_filter_frame(AVFilterLink *link, AVFrame *in)
     }
 
     tmp = ff_get_video_buffer(outlink, outlink->w, outlink->h);
-    if (!out) {
+    if (!tmp) {
         err = AVERROR(ENOMEM);
         goto fail;
     }

--- a/libavfilter/x86/vf_hflip_init.c
+++ b/libavfilter/x86/vf_hflip_init.c
@@ -25,8 +25,10 @@
 
 void ff_hflip_byte_ssse3(const uint8_t *src, uint8_t *dst, int w);
 void ff_hflip_byte_avx2(const uint8_t *src, uint8_t *dst, int w);
+void ff_hflip_byte_avx512(const uint8_t *src, uint8_t *dst, int w);
 void ff_hflip_short_ssse3(const uint8_t *src, uint8_t *dst, int w);
 void ff_hflip_short_avx2(const uint8_t *src, uint8_t *dst, int w);
+void ff_hflip_short_avx512(const uint8_t *src, uint8_t *dst, int w);
 
 av_cold void ff_hflip_init_x86(FlipContext *s, int step[4], int nb_planes)
 {
@@ -41,12 +43,18 @@ av_cold void ff_hflip_init_x86(FlipContext *s, int step[4], int nb_planes)
             if (EXTERNAL_AVX2_FAST(cpu_flags)) {
                 s->flip_line[i] = ff_hflip_byte_avx2;
             }
+            if (EXTERNAL_AVX512(cpu_flags)) {
+                s->flip_line[i] = ff_hflip_byte_avx512;
+            }
         } else if (step[i] == 2) {
             if (EXTERNAL_SSSE3(cpu_flags)) {
                 s->flip_line[i] = ff_hflip_short_ssse3;
             }
             if (EXTERNAL_AVX2_FAST(cpu_flags)) {
                 s->flip_line[i] = ff_hflip_short_avx2;
+            }
+            if (EXTERNAL_AVX512(cpu_flags)) {
+                s->flip_line[i] = ff_hflip_short_avx512;
             }
         }
     }

--- a/libavfilter/x86/vf_threshold_init.c
+++ b/libavfilter/x86/vf_threshold_init.c
@@ -34,8 +34,10 @@ void ff_threshold##depth##_##opt(const uint8_t *in, const uint8_t *threshold,\
 
 THRESHOLD_FUNC(8, sse4)
 THRESHOLD_FUNC(8, avx2)
+THRESHOLD_FUNC(8, avx512)
 THRESHOLD_FUNC(16, sse4)
 THRESHOLD_FUNC(16, avx2)
+THRESHOLD_FUNC(16, avx512)
 
 av_cold void ff_threshold_init_x86(ThresholdContext *s)
 {
@@ -48,12 +50,18 @@ av_cold void ff_threshold_init_x86(ThresholdContext *s)
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             s->threshold = ff_threshold8_avx2;
         }
+        if (EXTERNAL_AVX512(cpu_flags)) {
+            s->threshold = ff_threshold8_avx512;
+        }
     } else {
         if (EXTERNAL_SSE4(cpu_flags)) {
             s->threshold = ff_threshold16_sse4;
         }
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             s->threshold = ff_threshold16_avx2;
+        }
+        if (EXTERNAL_AVX512(cpu_flags)) {
+            s->threshold = ff_threshold16_avx512;
         }
     }
 }

--- a/libavfilter/x86/vf_threshold_init.c
+++ b/libavfilter/x86/vf_threshold_init.c
@@ -48,7 +48,7 @@ av_cold void ff_threshold_init_x86(ThresholdContext *s)
         if (EXTERNAL_AVX2_FAST(cpu_flags)) {
             s->threshold = ff_threshold8_avx2;
         }
-    } else if (s->depth == 16) {
+    } else {
         if (EXTERNAL_SSE4(cpu_flags)) {
             s->threshold = ff_threshold16_sse4;
         }


### PR DESCRIPTION
The patches fixed a problem by removing the `redundant condition` leading the *SIMD optimization* to be `uninitialized`.
Optimize hflip and threshold filter with AVX512 instructions. 

### Below is the test data(Less is better):
**8bit:**
    ff_hflip_byte_ssse3   0.61
    ff_hflip_byte_avx2    0.37
    ff_hflip_byte_avx512  0.19
**16bit:**
    ff_hflip_short_ssse3  1.27
    ff_hflip_short_avx2   0.76
    ff_hflip_short_avx512 0.40

**8bit:**
    ff_threshold8_sse4    32.75
    ff_threshold8_avx2    32.17
    ff_threshold8_avx512  32.01
**16bit:**
    ff_threshold16_sse4	  37.77
    ff_threshold16_avx2   35.33
    ff_threshold16_avx512 32.69