### PR TITLE
lavfi/dnn: Error Specificity

### DIFF
--- a/libavfilter/dnn/dnn_backend_common.c
+++ b/libavfilter/dnn/dnn_backend_common.c
@@ -53,13 +53,13 @@ int ff_check_exec_params(void *ctx, DNNBackendType backend, DNNFunctionType func
     return 0;
 }
 
-DNNReturnType ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int async, int do_ioproc) {
+int ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int async, int do_ioproc) {
     if (task == NULL || exec_params == NULL || backend_model == NULL)
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     if (do_ioproc != 0 && do_ioproc != 1)
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     if (async != 0 && async != 1)
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
 
     task->do_ioproc = do_ioproc;
     task->async = async;
@@ -89,17 +89,17 @@ static void *async_thread_routine(void *args)
     return DNN_ASYNC_SUCCESS;
 }
 
-DNNReturnType ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module)
+int ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module)
 {
     void *status = 0;
     if (!async_module) {
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 #if HAVE_PTHREAD_CANCEL
     pthread_join(async_module->thread_id, &status);
     if (status == DNN_ASYNC_FAIL) {
         av_log(NULL, AV_LOG_ERROR, "Last Inference Failed.\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 #endif
     async_module->start_inference = NULL;
@@ -108,30 +108,31 @@ DNNReturnType ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module)
     return DNN_SUCCESS;
 }
 
-DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module)
+int ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module)
 {
     int ret;
     void *status = 0;
 
     if (!async_module) {
         av_log(ctx, AV_LOG_ERROR, "async_module is null when starting async inference.\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
 #if HAVE_PTHREAD_CANCEL
     pthread_join(async_module->thread_id, &status);
     if (status == DNN_ASYNC_FAIL) {
         av_log(ctx, AV_LOG_ERROR, "Unable to start inference as previous inference failed.\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     ret = pthread_create(&async_module->thread_id, NULL, async_thread_routine, async_module);
     if (ret != 0) {
         av_log(ctx, AV_LOG_ERROR, "Unable to start async inference.\n");
-        return DNN_ERROR;
+        return ret;
     }
 #else
-    if (async_module->start_inference(async_module->args) != DNN_SUCCESS) {
-        return DNN_ERROR;
+    ret = async_module->start_inference(async_module->args);
+    if (ret != DNN_SUCCESS) {
+        return ret;
     }
     async_module->callback(async_module->args);
 #endif
@@ -158,7 +159,7 @@ DNNAsyncStatusType ff_dnn_get_result_common(Queue *task_queue, AVFrame **in, AVF
     return DAST_SUCCESS;
 }
 
-DNNReturnType ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx)
+int ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx)
 {
     AVFrame *in_frame = NULL;
     AVFrame *out_frame = NULL;
@@ -166,14 +167,14 @@ DNNReturnType ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *
     in_frame = av_frame_alloc();
     if (!in_frame) {
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input frame\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
     out_frame = av_frame_alloc();
     if (!out_frame) {
         av_frame_free(&in_frame);
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output frame\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
     in_frame->width = input_width;

--- a/libavfilter/dnn/dnn_backend_common.h
+++ b/libavfilter/dnn/dnn_backend_common.h
@@ -60,7 +60,7 @@ typedef struct DNNAsyncExecModule {
      * Synchronous inference function for the backend
      * with corresponding request item as the argument.
      */
-    DNNReturnType (*start_inference)(void *request);
+    int (*start_inference)(void *request);
 
     /**
      * Completion Callback for the backend.
@@ -92,20 +92,18 @@ int ff_check_exec_params(void *ctx, DNNBackendType backend, DNNFunctionType func
  * @param async flag for async execution. Must be 0 or 1
  * @param do_ioproc flag for IO processing. Must be 0 or 1
  *
- * @retval DNN_SUCCESS if successful
- * @retval DNN_ERROR if flags are invalid or any parameter is NULL
+ * @returns DNN_SUCCESS if successful or error code otherwise.
  */
-DNNReturnType ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int async, int do_ioproc);
+int ff_dnn_fill_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int async, int do_ioproc);
 
 /**
  * Join the Async Execution thread and set module pointers to NULL.
  *
  * @param async_module pointer to DNNAsyncExecModule module
  *
- * @retval DNN_SUCCESS if successful
- * @retval DNN_ERROR if async_module is NULL
+ * @returns DNN_SUCCESS if successful or error code otherwise.
  */
-DNNReturnType ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module);
+int ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module);
 
 /**
  * Start asynchronous inference routine for the TensorFlow
@@ -119,10 +117,9 @@ DNNReturnType ff_dnn_async_module_cleanup(DNNAsyncExecModule *async_module);
  * @param ctx pointer to the backend context
  * @param async_module pointer to DNNAsyncExecModule module
  *
- * @retval DNN_SUCCESS on the start of async inference.
- * @retval DNN_ERROR in case async inference cannot be started
+ * @returns DNN_SUCCESS on the start of async inference or error code otherwise.
  */
-DNNReturnType ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module);
+int ff_dnn_start_inference_async(void *ctx, DNNAsyncExecModule *async_module);
 
 /**
  * Extract input and output frame from the Task Queue after
@@ -149,9 +146,8 @@ DNNAsyncStatusType ff_dnn_get_result_common(Queue *task_queue, AVFrame **in, AVF
  * @param input_width width of input frame
  * @param ctx pointer to the backend context
  *
- * @retval DNN_SUCCESS if successful
- * @retval DNN_ERROR if allocation fails
+ * @returns DNN_SUCCESS if successful or error code otherwise.
  */
-DNNReturnType ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx);
+int ff_dnn_fill_gettingoutput_task(TaskItem *task, DNNExecBaseParams *exec_params, void *backend_model, int input_height, int input_width, void *ctx);
 
 #endif

--- a/libavfilter/dnn/dnn_backend_native.c
+++ b/libavfilter/dnn/dnn_backend_native.c
@@ -54,6 +54,13 @@ static const AVClass dnn_native_class = {
 static DNNReturnType execute_model_native(NativeRequestItem *request, Queue *lltask_queue);
 static void infer_completion_callback(void *args);
 
+/**
+ * Copy operands from the Operands in the Native Model
+ *
+ * @param native_model pointer to the native backend model
+ * @return Pointer to the newly created copy of DnnOperands.
+ * @retval NULL if memory cannot be allocated.
+ */
 static DnnOperand* copy_operands(NativeModel *native_model)
 {
     DnnOperand *original, *duplicate;
@@ -88,6 +95,12 @@ static DnnOperand* copy_operands(NativeModel *native_model)
     return duplicate;
 }
 
+/**
+ * Free the operands and their data in the NativeRequestItem
+ *
+ * @param request pointer to the NativeRequestItem
+ * @param numOperands number of operands
+ */
 static void native_free_request(NativeRequestItem *request, int32_t numOperands)
 {
     if (!request->operands)
@@ -99,6 +112,14 @@ static void native_free_request(NativeRequestItem *request, int32_t numOperands)
     av_freep(&request->operands);
 }
 
+/**
+ * Start synchronous inference of the model
+ *
+ * @param args pointer to the NativeRequestItem for execution.
+ * Data should already be filled in the input operand.
+ * @retval DNN_SUCCESS on successful execution
+ * @retval DNN_ERROR if unable to execute the model
+ */
 static DNNReturnType native_start_inference(void *args)
 {
     int32_t layer;

--- a/libavfilter/dnn/dnn_backend_native.h
+++ b/libavfilter/dnn/dnn_backend_native.h
@@ -30,6 +30,7 @@
 #include "../dnn_interface.h"
 #include "libavformat/avio.h"
 #include "libavutil/opt.h"
+#include "safe_queue.h"
 #include "queue.h"
 
 /**
@@ -112,6 +113,7 @@ typedef struct InputParams{
 
 typedef struct NativeOptions{
     uint8_t async;
+    uint32_t nireq;
     uint32_t conv2d_threads;
 } NativeOptions;
 
@@ -130,6 +132,7 @@ typedef struct NativeModel{
     int32_t operands_num;
     Queue *task_queue;
     Queue *lltask_queue;
+    SafeQueue *request_queue;
 } NativeModel;
 
 DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);

--- a/libavfilter/dnn/dnn_backend_native.h
+++ b/libavfilter/dnn/dnn_backend_native.h
@@ -137,11 +137,11 @@ typedef struct NativeModel{
 
 DNNModel *ff_dnn_load_model_native(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
-DNNReturnType ff_dnn_execute_model_native(const DNNModel *model, DNNExecBaseParams *exec_params);
+int ff_dnn_execute_model_native(const DNNModel *model, DNNExecBaseParams *exec_params);
 
 DNNAsyncStatusType ff_dnn_get_result_native(const DNNModel *model, AVFrame **in, AVFrame **out);
 
-DNNReturnType ff_dnn_flush_native(const DNNModel *model);
+int ff_dnn_flush_native(const DNNModel *model);
 
 void ff_dnn_free_model_native(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_backend_native_layer_avgpool.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_avgpool.c
@@ -109,12 +109,12 @@ int ff_dnn_execute_layer_avg_pool(DnnOperand *operands, const int32_t *input_ope
     output_operand->length = ff_calculate_operand_data_length(output_operand);
     if (output_operand->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output_operand->data = av_realloc(output_operand->data, output_operand->length);
     if (!output_operand->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     output = output_operand->data;
 
@@ -143,5 +143,5 @@ int ff_dnn_execute_layer_avg_pool(DnnOperand *operands, const int32_t *input_ope
         }
     }
 
-    return 0;
+    return DNN_SUCCESS;
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_avgpool.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_avgpool.h
@@ -60,7 +60,8 @@ int ff_dnn_load_layer_avg_pool(Layer *layer, AVIOContext *model_file_context, in
  * @param parameters average pooling parameters
  * @param ctx pointer to Native model context for logging
  * @retval 0 if the execution succeeds
- * @retval DNN_ERROR if the execution fails
+ * @retval AVERROR(ENOMEM) if memory allocation fails
+ * @retval AVERROR(EINVAL) for invalid arguments
  */
 int ff_dnn_execute_layer_avg_pool(DnnOperand *operands, const int32_t *input_operand_indexes,
                                   int32_t output_operand_index, const void *parameters, NativeContext *ctx);

--- a/libavfilter/dnn/dnn_backend_native_layer_conv2d.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_conv2d.c
@@ -218,12 +218,12 @@ int ff_dnn_execute_layer_conv2d(DnnOperand *operands, const int32_t *input_opera
     output_operand->length = ff_calculate_operand_data_length(output_operand);
     if (output_operand->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     tmp = av_realloc(output_operand->data, output_operand->length);
     if (!tmp) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     output_operand->data = tmp;
     thread_common_param.output_data = output_operand->data;
@@ -236,17 +236,19 @@ int ff_dnn_execute_layer_conv2d(DnnOperand *operands, const int32_t *input_opera
 #if HAVE_PTHREAD_CANCEL
     thread_param = av_malloc_array(thread_num, sizeof(*thread_param));
     if (!thread_param)
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     thread_stride = (height - pad_size * 2) / thread_num;
     //create threads
     for (int i = 0; i < thread_num; i++){
+        int thread_ret = 0;
         thread_param[i].thread_common_param = &thread_common_param;
         thread_param[i].thread_start = thread_stride * i + pad_size;
         thread_param[i].thread_end = (i == thread_num - 1) ? (height - pad_size) : (thread_param[i].thread_start + thread_stride);
-        if (pthread_create(&thread_param[i].thread, NULL,
-                           dnn_execute_layer_conv2d_thread, &thread_param[i])) {
+        thread_ret = pthread_create(&thread_param[i].thread, NULL,
+                           dnn_execute_layer_conv2d_thread, &thread_param[i]);
+        if (thread_ret) {
             thread_num = i;
-            ret = DNN_ERROR;
+            ret = AVERROR(thread_ret);
             break;
         }
     }

--- a/libavfilter/dnn/dnn_backend_native_layer_conv2d.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_conv2d.h
@@ -60,7 +60,8 @@ int ff_dnn_load_layer_conv2d(Layer *layer, AVIOContext *model_file_context, int 
  * @param parameters convolution parameters
  * @param ctx pointer to Native model context for logging
  * @retval 0 if the execution succeeds
- * @retval DNN_ERROR if the execution fails
+ * @retval AVERROR(ENOMEM) if memory allocation fails
+ * @retval AVERROR(EINVAL) for invalid arguments
  */
 int ff_dnn_execute_layer_conv2d(DnnOperand *operands, const int32_t *input_operand_indexes,
                                 int32_t output_operand_index, const void *parameters, NativeContext *ctx);

--- a/libavfilter/dnn/dnn_backend_native_layer_dense.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_dense.c
@@ -104,12 +104,12 @@ int ff_dnn_execute_layer_dense(DnnOperand *operands, const int32_t *input_operan
     output_operand->length = ff_calculate_operand_data_length(output_operand);
     if (output_operand->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output_operand->data = av_realloc(output_operand->data, output_operand->length);
     if (!output_operand->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     output = output_operand->data;
 
@@ -147,5 +147,5 @@ int ff_dnn_execute_layer_dense(DnnOperand *operands, const int32_t *input_operan
             output += dense_params->output_num;
         }
     }
-    return 0;
+    return DNN_SUCCESS;
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_dense.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_dense.h
@@ -57,7 +57,8 @@ int ff_dnn_load_layer_dense(Layer *layer, AVIOContext *model_file_context, int f
  * @param parameters dense layer parameters
  * @param ctx pointer to Native model context for logging
  * @retval 0 if the execution succeeds
- * @retval DNN_ERROR if the execution fails
+ * @retval AVERROR(ENOMEM) if memory allocation fails
+ * @retval AVERROR(EINVAL) for invalid arguments
  */
 int ff_dnn_execute_layer_dense(DnnOperand *operands, const int32_t *input_operand_indexes,
                                int32_t output_operand_index, const void *parameters, NativeContext *ctx);

--- a/libavfilter/dnn/dnn_backend_native_layer_depth2space.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_depth2space.c
@@ -76,12 +76,12 @@ int ff_dnn_execute_layer_depth2space(DnnOperand *operands, const int32_t *input_
     output_operand->length = ff_calculate_operand_data_length(output_operand);
     if (output_operand->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output_operand->data = av_realloc(output_operand->data, output_operand->length);
     if (!output_operand->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     output = output_operand->data;
 
@@ -98,5 +98,5 @@ int ff_dnn_execute_layer_depth2space(DnnOperand *operands, const int32_t *input_
         }
         output += output_linesize;
     }
-    return 0;
+    return DNN_SUCCESS;
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_depth2space.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_depth2space.h
@@ -63,7 +63,8 @@ int ff_dnn_load_layer_depth2space(Layer *layer, AVIOContext *model_file_context,
  * @param parameters depth to space layer parameters
  * @param ctx pointer to Native model context for logging
  * @retval 0 if the execution succeeds
- * @retval DNN_ERROR if the execution fails
+ * @retval AVERROR(ENOMEM) if memory allocation fails
+ * @retval AVERROR(EINVAL) for invalid arguments
  */
 int ff_dnn_execute_layer_depth2space(DnnOperand *operands, const int32_t *input_operand_indexes,
                                      int32_t output_operand_index, const void *parameters, NativeContext *ctx);

--- a/libavfilter/dnn/dnn_backend_native_layer_mathbinary.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathbinary.c
@@ -159,35 +159,35 @@ int ff_dnn_execute_layer_math_binary(DnnOperand *operands, const int32_t *input_
     output->length = ff_calculate_operand_data_length(output);
     if (output->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output->data = av_realloc(output->data, output->length);
     if (!output->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
     switch (params->bin_op) {
     case DMBO_SUB:
         math_binary_not_commutative(sub, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     case DMBO_ADD:
         math_binary_commutative(add, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     case DMBO_MUL:
         math_binary_commutative(mul, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     case DMBO_REALDIV:
         math_binary_not_commutative(realdiv, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     case DMBO_MINIMUM:
         math_binary_commutative(minimum, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     case DMBO_FLOORMOD:
         math_binary_not_commutative(floormod, params, input, output, operands, input_operand_indexes);
-        return 0;
+        return DNN_SUCCESS;
     default:
         av_log(ctx, AV_LOG_ERROR, "Unmatch math binary operator\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_mathunary.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathunary.c
@@ -68,12 +68,12 @@ int ff_dnn_execute_layer_math_unary(DnnOperand *operands, const int32_t *input_o
     output->length = ff_calculate_operand_data_length(output);
     if (output->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output->data = av_realloc(output->data, output->length);
     if (!output->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
     dims_count = ff_calculate_operand_dims_count(output);
@@ -151,6 +151,6 @@ int ff_dnn_execute_layer_math_unary(DnnOperand *operands, const int32_t *input_o
         return 0;
     default:
         av_log(ctx, AV_LOG_ERROR, "Unmatch math unary operator\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
+++ b/libavfilter/dnn/dnn_backend_native_layer_mathunary.h
@@ -83,7 +83,8 @@ int ff_dnn_load_layer_math_unary(Layer *layer, AVIOContext *model_file_context, 
  * @param parameters unary math layer parameters
  * @param ctx pointer to Native model context for logging
  * @retval 0 if the execution succeeds
- * @retval DNN_ERROR if the execution fails
+ * @retval AVERROR(ENOMEM) if memory allocation fails
+ * @retval AVERROR(EINVAL) for invalid arguments
  */
 int ff_dnn_execute_layer_math_unary(DnnOperand *operands, const int32_t *input_operand_indexes,
                                     int32_t output_operand_index, const void *parameters, NativeContext *ctx);

--- a/libavfilter/dnn/dnn_backend_native_layer_maximum.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_maximum.c
@@ -65,12 +65,12 @@ int ff_dnn_execute_layer_maximum(DnnOperand *operands, const int32_t *input_oper
     output->length = ff_calculate_operand_data_length(output);
     if (output->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output->data = av_realloc(output->data, output->length);
     if (!output->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
     dims_count = ff_calculate_operand_dims_count(output);
@@ -79,5 +79,5 @@ int ff_dnn_execute_layer_maximum(DnnOperand *operands, const int32_t *input_oper
     for (int i = 0; i < dims_count; ++i)
         dst[i] = FFMAX(src[i], params->val.y);
 
-    return 0;
+    return DNN_SUCCESS;
 }

--- a/libavfilter/dnn/dnn_backend_native_layer_pad.c
+++ b/libavfilter/dnn/dnn_backend_native_layer_pad.c
@@ -113,12 +113,12 @@ int ff_dnn_execute_layer_pad(DnnOperand *operands, const int32_t *input_operand_
     output_operand->length = ff_calculate_operand_data_length(output_operand);
     if (output_operand->length <= 0) {
         av_log(ctx, AV_LOG_ERROR, "The output data length overflow\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     output_operand->data = av_realloc(output_operand->data, output_operand->length);
     if (!output_operand->data) {
         av_log(ctx, AV_LOG_ERROR, "Failed to reallocate memory for output\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     output = output_operand->data;
 

--- a/libavfilter/dnn/dnn_backend_openvino.c
+++ b/libavfilter/dnn/dnn_backend_openvino.c
@@ -112,7 +112,7 @@ static int get_datatype_size(DNNDataType dt)
     }
 }
 
-static DNNReturnType fill_model_input_ov(OVModel *ov_model, OVRequestItem *request)
+static int fill_model_input_ov(OVModel *ov_model, OVRequestItem *request)
 {
     dimensions_t dims;
     precision_e precision;
@@ -131,7 +131,7 @@ static DNNReturnType fill_model_input_ov(OVModel *ov_model, OVRequestItem *reque
     status = ie_infer_request_get_blob(request->infer_request, task->input_name, &input_blob);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to get input blob with name %s\n", task->input_name);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     status |= ie_blob_get_dims(input_blob, &dims);
@@ -139,14 +139,14 @@ static DNNReturnType fill_model_input_ov(OVModel *ov_model, OVRequestItem *reque
     if (status != OK) {
         ie_blob_free(&input_blob);
         av_log(ctx, AV_LOG_ERROR, "Failed to get input blob dims/precision\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     status = ie_blob_get_buffer(input_blob, &blob_buffer);
     if (status != OK) {
         ie_blob_free(&input_blob);
         av_log(ctx, AV_LOG_ERROR, "Failed to get input blob buffer\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     input.height = dims.dims[2];
@@ -301,8 +301,9 @@ static void infer_completion_callback(void *args)
     }
 }
 
-static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, const char *output_name)
+static int init_model_ov(OVModel *ov_model, const char *input_name, const char *output_name)
 {
+    int ret = DNN_SUCCESS;
     OVContext *ctx = &ov_model->ctx;
     IEStatusCode status;
     ie_available_devices_t a_dev;
@@ -317,14 +318,18 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
     if (ctx->options.batch_size > 1) {
         input_shapes_t input_shapes;
         status = ie_network_get_input_shapes(ov_model->network, &input_shapes);
-        if (status != OK)
+        if (status != OK) {
+            ret = DNN_GENERIC_ERROR;
             goto err;
+        }
         for (int i = 0; i < input_shapes.shape_num; i++)
             input_shapes.shapes[i].shape.dims[0] = ctx->options.batch_size;
         status = ie_network_reshape(ov_model->network, input_shapes);
         ie_network_input_shapes_free(&input_shapes);
-        if (status != OK)
+        if (status != OK) {
+            ret = DNN_GENERIC_ERROR;
             goto err;
+        }
     }
 
     // The order of dims in the openvino is fixed and it is always NCHW for 4-D data.
@@ -332,11 +337,13 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
     status = ie_network_set_input_layout(ov_model->network, input_name, NHWC);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to set layout as NHWC for input %s\n", input_name);
+        ret = DNN_GENERIC_ERROR;
         goto err;
     }
     status = ie_network_set_output_layout(ov_model->network, output_name, NHWC);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to set layout as NHWC for output %s\n", output_name);
+        ret = DNN_GENERIC_ERROR;
         goto err;
     }
 
@@ -350,6 +357,7 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
         status = ie_network_set_input_precision(ov_model->network, input_name, U8);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to set input precision as U8 for %s\n", input_name);
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
     }
@@ -360,6 +368,7 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
         status = ie_core_get_available_devices(ov_model->core, &a_dev);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to get available devices\n");
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
         for (int i = 0; i < a_dev.num_devices; i++) {
@@ -367,6 +376,7 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
         }
         av_log(ctx, AV_LOG_ERROR,"device %s may not be supported, all available devices are: \"%s\"\n",
                ctx->options.device_type, all_dev_names);
+        ret = AVERROR(ENODEV);
         goto err;
     }
 
@@ -378,12 +388,14 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
 
     ov_model->request_queue = ff_safe_queue_create();
     if (!ov_model->request_queue) {
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
     for (int i = 0; i < ctx->options.nireq; i++) {
         OVRequestItem *item = av_mallocz(sizeof(*item));
         if (!item) {
+            ret = AVERROR(ENOMEM);
             goto err;
         }
 
@@ -391,16 +403,19 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
         item->callback.args = item;
         if (ff_safe_queue_push_back(ov_model->request_queue, item) < 0) {
             av_freep(&item);
+            ret = AVERROR(ENOMEM);
             goto err;
         }
 
         status = ie_exec_network_create_infer_request(ov_model->exe_network, &item->infer_request);
         if (status != OK) {
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
 
         item->lltasks = av_malloc_array(ctx->options.batch_size, sizeof(*item->lltasks));
         if (!item->lltasks) {
+            ret = AVERROR(ENOMEM);
             goto err;
         }
         item->lltask_count = 0;
@@ -408,11 +423,13 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
 
     ov_model->task_queue = ff_queue_create();
     if (!ov_model->task_queue) {
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
     ov_model->lltask_queue = ff_queue_create();
     if (!ov_model->lltask_queue) {
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
@@ -420,14 +437,14 @@ static DNNReturnType init_model_ov(OVModel *ov_model, const char *input_name, co
 
 err:
     ff_dnn_free_model_ov(&ov_model->model);
-    return DNN_ERROR;
+    return ret;
 }
 
-static DNNReturnType execute_model_ov(OVRequestItem *request, Queue *inferenceq)
+static int execute_model_ov(OVRequestItem *request, Queue *inferenceq)
 {
     IEStatusCode status;
-    DNNReturnType ret;
     LastLevelTaskItem *lltask;
+    int ret = DNN_SUCCESS;
     TaskItem *task;
     OVContext *ctx;
     OVModel *ov_model;
@@ -451,11 +468,13 @@ static DNNReturnType execute_model_ov(OVRequestItem *request, Queue *inferenceq)
         status = ie_infer_set_completion_callback(request->infer_request, &request->callback);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to set completion callback for inference\n");
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
         status = ie_infer_request_infer_async(request->infer_request);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to start async inference\n");
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
         return DNN_SUCCESS;
@@ -467,20 +486,21 @@ static DNNReturnType execute_model_ov(OVRequestItem *request, Queue *inferenceq)
         status = ie_infer_request_infer(request->infer_request);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to start synchronous model inference\n");
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
         infer_completion_callback(request);
-        return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_ERROR;
+        return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_GENERIC_ERROR;
     }
 err:
     if (ff_safe_queue_push_back(ov_model->request_queue, request) < 0) {
         ie_infer_request_free(&request->infer_request);
         av_freep(&request);
     }
-    return DNN_ERROR;
+    return ret;
 }
 
-static DNNReturnType get_input_ov(void *model, DNNData *input, const char *input_name)
+static int get_input_ov(void *model, DNNData *input, const char *input_name)
 {
     OVModel *ov_model = model;
     OVContext *ctx = &ov_model->ctx;
@@ -495,14 +515,14 @@ static DNNReturnType get_input_ov(void *model, DNNData *input, const char *input
     status = ie_network_get_inputs_number(ov_model->network, &model_input_count);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to get input count\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     for (size_t i = 0; i < model_input_count; i++) {
         status = ie_network_get_input_name(ov_model->network, i, &model_input_name);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to get No.%d input's name\n", (int)i);
-            return DNN_ERROR;
+            return DNN_GENERIC_ERROR;
         }
         if (strcmp(model_input_name, input_name) == 0) {
             ie_network_name_free(&model_input_name);
@@ -510,7 +530,7 @@ static DNNReturnType get_input_ov(void *model, DNNData *input, const char *input
             status |= ie_network_get_input_precision(ov_model->network, input_name, &precision);
             if (status != OK) {
                 av_log(ctx, AV_LOG_ERROR, "Failed to get No.%d input's dims or precision\n", (int)i);
-                return DNN_ERROR;
+                return DNN_GENERIC_ERROR;
             }
 
             input->channels = dims.dims[1];
@@ -527,7 +547,7 @@ static DNNReturnType get_input_ov(void *model, DNNData *input, const char *input
     }
 
     av_log(ctx, AV_LOG_ERROR, "Could not find \"%s\" in model, all input(s) are: \"%s\"\n", input_name, all_input_names);
-    return DNN_ERROR;
+    return AVERROR(EINVAL);
 }
 
 static int contain_valid_detection_bbox(AVFrame *frame)
@@ -567,7 +587,7 @@ static int contain_valid_detection_bbox(AVFrame *frame)
     return 1;
 }
 
-static DNNReturnType extract_lltask_from_task(DNNFunctionType func_type, TaskItem *task, Queue *lltask_queue, DNNExecBaseParams *exec_params)
+static int extract_lltask_from_task(DNNFunctionType func_type, TaskItem *task, Queue *lltask_queue, DNNExecBaseParams *exec_params)
 {
     switch (func_type) {
     case DFT_PROCESS_FRAME:
@@ -575,14 +595,14 @@ static DNNReturnType extract_lltask_from_task(DNNFunctionType func_type, TaskIte
     {
         LastLevelTaskItem *lltask = av_malloc(sizeof(*lltask));
         if (!lltask) {
-            return DNN_ERROR;
+            return AVERROR(ENOMEM);
         }
         task->inference_todo = 1;
         task->inference_done = 0;
         lltask->task = task;
         if (ff_queue_push_back(lltask_queue, lltask) < 0) {
             av_freep(&lltask);
-            return DNN_ERROR;
+            return AVERROR(ENOMEM);
         }
         return DNN_SUCCESS;
     }
@@ -615,28 +635,28 @@ static DNNReturnType extract_lltask_from_task(DNNFunctionType func_type, TaskIte
 
             lltask = av_malloc(sizeof(*lltask));
             if (!lltask) {
-                return DNN_ERROR;
+                return AVERROR(ENOMEM);
             }
             task->inference_todo++;
             lltask->task = task;
             lltask->bbox_index = i;
             if (ff_queue_push_back(lltask_queue, lltask) < 0) {
                 av_freep(&lltask);
-                return DNN_ERROR;
+                return AVERROR(ENOMEM);
             }
         }
         return DNN_SUCCESS;
     }
     default:
         av_assert0(!"should not reach here");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 }
 
-static DNNReturnType get_output_ov(void *model, const char *input_name, int input_width, int input_height,
+static int get_output_ov(void *model, const char *input_name, int input_width, int input_height,
                                    const char *output_name, int *output_width, int *output_height)
 {
-    DNNReturnType ret;
+    int ret;
     OVModel *ov_model = model;
     OVContext *ctx = &ov_model->ctx;
     TaskItem task;
@@ -653,7 +673,7 @@ static DNNReturnType get_output_ov(void *model, const char *input_name, int inpu
 
     if (ov_model->model->func_type != DFT_PROCESS_FRAME) {
         av_log(ctx, AV_LOG_ERROR, "Get output dim only when processing frame.\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     if (ctx->options.input_resizable) {
@@ -664,31 +684,33 @@ static DNNReturnType get_output_ov(void *model, const char *input_name, int inpu
         ie_network_input_shapes_free(&input_shapes);
         if (status != OK) {
             av_log(ctx, AV_LOG_ERROR, "Failed to reshape input size for %s\n", input_name);
-            return DNN_ERROR;
+            return DNN_GENERIC_ERROR;
         }
     }
 
     if (!ov_model->exe_network) {
-        if (init_model_ov(ov_model, input_name, output_name) != DNN_SUCCESS) {
+        ret = init_model_ov(ov_model, input_name, output_name);
+        if (ret != DNN_SUCCESS) {
             av_log(ctx, AV_LOG_ERROR, "Failed init OpenVINO exectuable network or inference request\n");
-            return DNN_ERROR;
+            return ret;
         }
     }
 
-    if (ff_dnn_fill_gettingoutput_task(&task, &exec_params, ov_model, input_height, input_width, ctx) != DNN_SUCCESS) {
-        return DNN_ERROR;
+    ret = ff_dnn_fill_gettingoutput_task(&task, &exec_params, ov_model, input_height, input_width, ctx);
+    if (ret != DNN_SUCCESS) {
+        goto err;
     }
 
-    if (extract_lltask_from_task(ov_model->model->func_type, &task, ov_model->lltask_queue, NULL) != DNN_SUCCESS) {
-        av_log(ctx, AV_LOG_ERROR, "unable to extract last level task from task.\n");
-        ret = DNN_ERROR;
+    ret = extract_lltask_from_task(ov_model->model->func_type, &task, ov_model->lltask_queue, NULL);
+    if (ret != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
         goto err;
     }
 
     request = ff_safe_queue_pop_front(ov_model->request_queue);
     if (!request) {
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-        ret = DNN_ERROR;
+        ret = AVERROR(EINVAL);
         goto err;
     }
 
@@ -758,45 +780,49 @@ err:
     return NULL;
 }
 
-DNNReturnType ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *exec_params)
+int ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *exec_params)
 {
     OVModel *ov_model = model->model;
     OVContext *ctx = &ov_model->ctx;
     OVRequestItem *request;
     TaskItem *task;
-    DNNReturnType ret;
+    int ret;
 
-    if (ff_check_exec_params(ctx, DNN_OV, model->func_type, exec_params) != 0) {
-        return DNN_ERROR;
+    ret = ff_check_exec_params(ctx, DNN_OV, model->func_type, exec_params);
+    if (ret != 0) {
+        return ret;
     }
 
     if (!ov_model->exe_network) {
-        if (init_model_ov(ov_model, exec_params->input_name, exec_params->output_names[0]) != DNN_SUCCESS) {
+        ret = init_model_ov(ov_model, exec_params->input_name, exec_params->output_names[0]);
+        if (ret != DNN_SUCCESS) {
             av_log(ctx, AV_LOG_ERROR, "Failed init OpenVINO exectuable network or inference request\n");
-            return DNN_ERROR;
+            return ret;
         }
     }
 
     task = av_malloc(sizeof(*task));
     if (!task) {
         av_log(ctx, AV_LOG_ERROR, "unable to alloc memory for task item.\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
-    if (ff_dnn_fill_task(task, exec_params, ov_model, ctx->options.async, 1) != DNN_SUCCESS) {
+    ret = ff_dnn_fill_task(task, exec_params, ov_model, ctx->options.async, 1);
+    if (ret != DNN_SUCCESS) {
         av_freep(&task);
-        return DNN_ERROR;
+        return ret;
     }
 
     if (ff_queue_push_back(ov_model->task_queue, task) < 0) {
         av_freep(&task);
         av_log(ctx, AV_LOG_ERROR, "unable to push back task_queue.\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
-    if (extract_lltask_from_task(model->func_type, task, ov_model->lltask_queue, exec_params) != DNN_SUCCESS) {
+    ret = extract_lltask_from_task(model->func_type, task, ov_model->lltask_queue, exec_params);
+    if (ret != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
-        return DNN_ERROR;
+        return ret;
     }
 
     if (ctx->options.async) {
@@ -804,7 +830,7 @@ DNNReturnType ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *
             request = ff_safe_queue_pop_front(ov_model->request_queue);
             if (!request) {
                 av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-                return DNN_ERROR;
+                return AVERROR(EINVAL);
             }
 
             ret = execute_model_ov(request, ov_model->lltask_queue);
@@ -820,18 +846,18 @@ DNNReturnType ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *
             // Classification filter has not been completely
             // tested with the sync mode. So, do not support now.
             avpriv_report_missing_feature(ctx, "classify for sync execution");
-            return DNN_ERROR;
+            return AVERROR(ENOSYS);
         }
 
         if (ctx->options.batch_size > 1) {
             avpriv_report_missing_feature(ctx, "batch mode for sync execution");
-            return DNN_ERROR;
+            return AVERROR(ENOSYS);
         }
 
         request = ff_safe_queue_pop_front(ov_model->request_queue);
         if (!request) {
             av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         return execute_model_ov(request, ov_model->lltask_queue);
     }
@@ -843,13 +869,13 @@ DNNAsyncStatusType ff_dnn_get_result_ov(const DNNModel *model, AVFrame **in, AVF
     return ff_dnn_get_result_common(ov_model->task_queue, in, out);
 }
 
-DNNReturnType ff_dnn_flush_ov(const DNNModel *model)
+int ff_dnn_flush_ov(const DNNModel *model)
 {
     OVModel *ov_model = model->model;
     OVContext *ctx = &ov_model->ctx;
     OVRequestItem *request;
     IEStatusCode status;
-    DNNReturnType ret;
+    int ret;
 
     if (ff_queue_size(ov_model->lltask_queue) == 0) {
         // no pending task need to flush
@@ -859,7 +885,7 @@ DNNReturnType ff_dnn_flush_ov(const DNNModel *model)
     request = ff_safe_queue_pop_front(ov_model->request_queue);
     if (!request) {
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     ret = fill_model_input_ov(ov_model, request);
@@ -870,12 +896,12 @@ DNNReturnType ff_dnn_flush_ov(const DNNModel *model)
     status = ie_infer_set_completion_callback(request->infer_request, &request->callback);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to set completion callback for inference\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     status = ie_infer_request_infer_async(request->infer_request);
     if (status != OK) {
         av_log(ctx, AV_LOG_ERROR, "Failed to start async inference\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     return DNN_SUCCESS;

--- a/libavfilter/dnn/dnn_backend_openvino.h
+++ b/libavfilter/dnn/dnn_backend_openvino.h
@@ -31,9 +31,9 @@
 
 DNNModel *ff_dnn_load_model_ov(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
-DNNReturnType ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *exec_params);
+int ff_dnn_execute_model_ov(const DNNModel *model, DNNExecBaseParams *exec_params);
 DNNAsyncStatusType ff_dnn_get_result_ov(const DNNModel *model, AVFrame **in, AVFrame **out);
-DNNReturnType ff_dnn_flush_ov(const DNNModel *model);
+int ff_dnn_flush_ov(const DNNModel *model);
 
 void ff_dnn_free_model_ov(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -93,7 +93,7 @@ static const AVOption dnn_tensorflow_options[] = {
 
 AVFILTER_DEFINE_CLASS(dnn_tensorflow);
 
-static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *lltask_queue);
+static int execute_model_tf(TFRequestItem *request, Queue *lltask_queue);
 static void infer_completion_callback(void *args);
 static inline void destroy_request_item(TFRequestItem **arg);
 
@@ -155,9 +155,10 @@ static TFInferRequest *tf_create_inference_request(void)
  *
  * @param request pointer to the TFRequestItem for inference
  * @retval DNN_SUCCESS if execution is successful
- * @retval DNN_ERROR if execution fails
+ * @retval AVERROR(EINVAL) if request is NULL
+ * @retval DNN_GENERIC_ERROR if execution fails
  */
-static DNNReturnType tf_start_inference(void *args)
+static int tf_start_inference(void *args)
 {
     TFRequestItem *request = args;
     TFInferRequest *infer_request = request->infer_request;
@@ -167,7 +168,7 @@ static DNNReturnType tf_start_inference(void *args)
 
     if (!request) {
         av_log(&tf_model->ctx, AV_LOG_ERROR, "TFRequestItem is NULL\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     TF_SessionRun(tf_model->session, NULL,
@@ -181,7 +182,7 @@ static DNNReturnType tf_start_inference(void *args)
         if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
             destroy_request_item(&request);
         }
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     return DNN_SUCCESS;
 }
@@ -208,14 +209,14 @@ static inline void destroy_request_item(TFRequestItem **arg) {
     av_freep(arg);
 }
 
-static DNNReturnType extract_lltask_from_task(TaskItem *task, Queue *lltask_queue)
+static int extract_lltask_from_task(TaskItem *task, Queue *lltask_queue)
 {
     TFModel *tf_model = task->model;
     TFContext *ctx = &tf_model->ctx;
     LastLevelTaskItem *lltask = av_malloc(sizeof(*lltask));
     if (!lltask) {
         av_log(ctx, AV_LOG_ERROR, "Unable to allocate space for LastLevelTaskItem\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     task->inference_todo = 1;
     task->inference_done = 0;
@@ -223,7 +224,7 @@ static DNNReturnType extract_lltask_from_task(TaskItem *task, Queue *lltask_queu
     if (ff_queue_push_back(lltask_queue, lltask) < 0) {
         av_log(ctx, AV_LOG_ERROR, "Failed to push back lltask_queue.\n");
         av_freep(&lltask);
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
     return DNN_SUCCESS;
 }
@@ -283,7 +284,7 @@ static TF_Tensor *allocate_input_tensor(const DNNData *input, const int batch_si
                              input_dims[0] * input_dims[1] * input_dims[2] * input_dims[3] * size);
 }
 
-static DNNReturnType get_input_tf(void *model, DNNData *input, const char *input_name)
+static int get_input_tf(void *model, DNNData *input, const char *input_name)
 {
     TFModel *tf_model = model;
     TFContext *ctx = &tf_model->ctx;
@@ -294,7 +295,7 @@ static DNNReturnType get_input_tf(void *model, DNNData *input, const char *input
     tf_output.oper = TF_GraphOperationByName(tf_model->graph, input_name);
     if (!tf_output.oper) {
         av_log(ctx, AV_LOG_ERROR, "Could not find \"%s\" in model\n", input_name);
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     tf_output.index = 0;
@@ -306,7 +307,7 @@ static DNNReturnType get_input_tf(void *model, DNNData *input, const char *input
     if (TF_GetCode(status) != TF_OK){
         TF_DeleteStatus(status);
         av_log(ctx, AV_LOG_ERROR, "Failed to get input tensor shape: number of dimension incorrect\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     TF_DeleteStatus(status);
 
@@ -318,10 +319,10 @@ static DNNReturnType get_input_tf(void *model, DNNData *input, const char *input
     return DNN_SUCCESS;
 }
 
-static DNNReturnType get_output_tf(void *model, const char *input_name, int input_width, int input_height,
+static int get_output_tf(void *model, const char *input_name, int input_width, int input_height,
                                    const char *output_name, int *output_width, int *output_height)
 {
-    DNNReturnType ret;
+    int ret;
     TFModel *tf_model = model;
     TFContext *ctx = &tf_model->ctx;
     TaskItem task;
@@ -334,20 +335,21 @@ static DNNReturnType get_output_tf(void *model, const char *input_name, int inpu
         .out_frame      = NULL,
     };
 
-    if (ff_dnn_fill_gettingoutput_task(&task, &exec_params, tf_model, input_height, input_width, ctx) != DNN_SUCCESS) {
+    ret = ff_dnn_fill_gettingoutput_task(&task, &exec_params, tf_model, input_height, input_width, ctx);
+    if (ret != DNN_SUCCESS) {
         goto err;
     }
 
-    if (extract_lltask_from_task(&task, tf_model->lltask_queue) != DNN_SUCCESS) {
-        av_log(ctx, AV_LOG_ERROR, "unable to extract last level task item from task.\n");
-        ret = DNN_ERROR;
+    ret = extract_lltask_from_task(&task, tf_model->lltask_queue);
+    if (ret != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "unable to extract inference from task.\n");
         goto err;
     }
 
     request = ff_safe_queue_pop_front(tf_model->request_queue);
     if (!request) {
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-        ret = DNN_ERROR;
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
@@ -391,7 +393,7 @@ static int hex_to_data(uint8_t *data, const char *p)
     return len;
 }
 
-static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename)
+static int load_tf_model(TFModel *tf_model, const char *model_filename)
 {
     TFContext *ctx = &tf_model->ctx;
     TF_Buffer *graph_def;
@@ -412,7 +414,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
         */
         if (strncmp(tf_model->ctx.options.sess_config, "0x", 2) != 0) {
             av_log(ctx, AV_LOG_ERROR, "sess_config should start with '0x'\n");
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         config = tf_model->ctx.options.sess_config + 2;
         sess_config_length = hex_to_data(NULL, config);
@@ -420,11 +422,11 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
         sess_config = av_mallocz(sess_config_length + AV_INPUT_BUFFER_PADDING_SIZE);
         if (!sess_config) {
             av_log(ctx, AV_LOG_ERROR, "failed to allocate memory\n");
-            return DNN_ERROR;
+            return AVERROR(ENOMEM);
         }
         if (hex_to_data(sess_config, config) < 0) {
             av_log(ctx, AV_LOG_ERROR, "failed to convert hex to data\n");
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
     }
 
@@ -432,7 +434,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
     if (!graph_def){
         av_log(ctx, AV_LOG_ERROR, "Failed to read model \"%s\" graph\n", model_filename);
         av_freep(&sess_config);
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     tf_model->graph = TF_NewGraph();
     tf_model->status = TF_NewStatus();
@@ -445,7 +447,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
         TF_DeleteStatus(tf_model->status);
         av_log(ctx, AV_LOG_ERROR, "Failed to import serialized graph to model graph\n");
         av_freep(&sess_config);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     init_op = TF_GraphOperationByName(tf_model->graph, "init");
@@ -460,7 +462,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
             TF_DeleteSessionOptions(sess_opts);
             av_log(ctx, AV_LOG_ERROR, "Failed to set config for sess options with %s\n",
                                       tf_model->ctx.options.sess_config);
-            return DNN_ERROR;
+            return DNN_GENERIC_ERROR;
         }
     }
 
@@ -471,7 +473,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
         TF_DeleteGraph(tf_model->graph);
         TF_DeleteStatus(tf_model->status);
         av_log(ctx, AV_LOG_ERROR, "Failed to create new session with model graph\n");
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     // Run initialization operation with name "init" if it is present in graph
@@ -486,7 +488,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
             TF_DeleteGraph(tf_model->graph);
             TF_DeleteStatus(tf_model->status);
             av_log(ctx, AV_LOG_ERROR, "Failed to run session when initializing\n");
-            return DNN_ERROR;
+            return DNN_GENERIC_ERROR;
         }
     }
 
@@ -495,7 +497,7 @@ static DNNReturnType load_tf_model(TFModel *tf_model, const char *model_filename
 
 #define NAME_BUFFER_SIZE 256
 
-static DNNReturnType add_conv_layer(TFModel *tf_model, TF_Operation *transpose_op, TF_Operation **cur_op,
+static int add_conv_layer(TFModel *tf_model, TF_Operation *transpose_op, TF_Operation **cur_op,
                                     ConvolutionalParams* params, const int layer)
 {
     TFContext *ctx = &tf_model->ctx;
@@ -599,7 +601,7 @@ static DNNReturnType add_conv_layer(TFModel *tf_model, TF_Operation *transpose_o
         break;
     default:
         avpriv_report_missing_feature(ctx, "convolutional activation function %d", params->activation);
-        return DNN_ERROR;
+        return AVERROR(ENOSYS);
     }
     input.oper = *cur_op;
     TF_AddInput(op_desc, input);
@@ -614,10 +616,10 @@ err:
     TF_DeleteTensor(kernel_tensor);
     TF_DeleteTensor(biases_tensor);
     av_log(ctx, AV_LOG_ERROR, "Failed to add conv layer %d\n", layer);
-    return DNN_ERROR;
+    return DNN_GENERIC_ERROR;
 }
 
-static DNNReturnType add_depth_to_space_layer(TFModel *tf_model, TF_Operation **cur_op,
+static int add_depth_to_space_layer(TFModel *tf_model, TF_Operation **cur_op,
                                               DepthToSpaceParams *params, const int layer)
 {
     TFContext *ctx = &tf_model->ctx;
@@ -635,13 +637,13 @@ static DNNReturnType add_depth_to_space_layer(TFModel *tf_model, TF_Operation **
     *cur_op = TF_FinishOperation(op_desc, tf_model->status);
     if (TF_GetCode(tf_model->status) != TF_OK){
         av_log(ctx, AV_LOG_ERROR, "Failed to add depth_to_space to layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     return DNN_SUCCESS;
 }
 
-static DNNReturnType add_pad_layer(TFModel *tf_model, TF_Operation **cur_op,
+static int add_pad_layer(TFModel *tf_model, TF_Operation **cur_op,
                                               LayerPadParams *params, const int layer)
 {
     TFContext *ctx = &tf_model->ctx;
@@ -671,13 +673,13 @@ static DNNReturnType add_pad_layer(TFModel *tf_model, TF_Operation **cur_op,
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to set value for pad of layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     op = TF_FinishOperation(op_desc, tf_model->status);
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to add pad to layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     op_desc = TF_NewOperation(tf_model->graph, "MirrorPad", "mirror_pad");
@@ -693,13 +695,13 @@ static DNNReturnType add_pad_layer(TFModel *tf_model, TF_Operation **cur_op,
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to add mirror_pad to layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     return DNN_SUCCESS;
 }
 
-static DNNReturnType add_maximum_layer(TFModel *tf_model, TF_Operation **cur_op,
+static int add_maximum_layer(TFModel *tf_model, TF_Operation **cur_op,
                                        DnnLayerMaximumParams *params, const int layer)
 {
     TFContext *ctx = &tf_model->ctx;
@@ -721,13 +723,13 @@ static DNNReturnType add_maximum_layer(TFModel *tf_model, TF_Operation **cur_op,
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to set value for maximum/y of layer %d", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
     op = TF_FinishOperation(op_desc, tf_model->status);
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to add maximum/y to layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     snprintf(name_buffer, NAME_BUFFER_SIZE, "maximum%d", layer);
@@ -742,13 +744,13 @@ static DNNReturnType add_maximum_layer(TFModel *tf_model, TF_Operation **cur_op,
     if (TF_GetCode(tf_model->status) != TF_OK){
         TF_DeleteTensor(tensor);
         av_log(ctx, AV_LOG_ERROR, "Failed to add maximum to layer %d\n", layer);
-        return DNN_ERROR;
+        return DNN_GENERIC_ERROR;
     }
 
     return DNN_SUCCESS;
 }
 
-static DNNReturnType load_native_model(TFModel *tf_model, const char *model_filename)
+static int load_native_model(TFModel *tf_model, const char *model_filename)
 {
     TFContext *ctx = &tf_model->ctx;
     int32_t layer;
@@ -760,14 +762,14 @@ static DNNReturnType load_native_model(TFModel *tf_model, const char *model_file
     int32_t *transpose_perm;
     int64_t transpose_perm_shape[] = {4};
     int64_t input_shape[] = {1, -1, -1, -1};
-    DNNReturnType layer_add_res;
+    int layer_add_res;
     DNNModel *model = NULL;
     NativeModel *native_model;
 
     model = ff_dnn_load_model_native(model_filename, DFT_PROCESS_FRAME, NULL, NULL);
     if (!model){
         av_log(ctx, AV_LOG_ERROR, "Failed to load native model\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     native_model = model->model;
@@ -780,7 +782,7 @@ static DNNReturnType load_native_model(TFModel *tf_model, const char *model_file
         TF_DeleteGraph(tf_model->graph); \
         TF_DeleteStatus(tf_model->status); \
         av_log(ctx, AV_LOG_ERROR, "Failed to set value or add operator to layer\n"); \
-        return DNN_ERROR; \
+        return DNN_GENERIC_ERROR; \
     }
 
     op_desc = TF_NewOperation(tf_model->graph, "Placeholder", "x");
@@ -956,7 +958,7 @@ err:
     return NULL;
 }
 
-static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *request) {
+static int fill_model_input_tf(TFModel *tf_model, TFRequestItem *request) {
     DNNData input;
     LastLevelTaskItem *lltask;
     TaskItem *task;
@@ -964,6 +966,7 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     TFContext *ctx = &tf_model->ctx;
     uint64_t offset = 0;
     int current_batch_size = ctx->options.batch_size;
+    int ret = 0;
 
     if (current_batch_size > ff_queue_size(tf_model->lltask_queue)) {
         current_batch_size = ff_queue_size(tf_model->lltask_queue);
@@ -973,7 +976,8 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     av_assert0(lltask);
     task = lltask->task;
 
-    if (get_input_tf(tf_model, &input, task->input_name) != DNN_SUCCESS) {
+    ret = get_input_tf(tf_model, &input, task->input_name);
+    if (ret != DNN_SUCCESS) {
         goto err;
     }
 
@@ -984,12 +988,14 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     infer_request->tf_input = av_malloc(sizeof(TF_Output));
     if (!infer_request->tf_input) {
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input tensor\n");
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
     infer_request->tf_input->oper = TF_GraphOperationByName(tf_model->graph, task->input_name);
     if (!infer_request->tf_input->oper){
         av_log(ctx, AV_LOG_ERROR, "Could not find \"%s\" in model\n", task->input_name);
+        ret = DNN_GENERIC_ERROR;
         goto err;
     }
     infer_request->tf_input->index = 0;
@@ -997,6 +1003,7 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     infer_request->input_tensor = allocate_input_tensor(&input, current_batch_size);
     if (!infer_request->input_tensor){
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for input tensor\n");
+        ret = AVERROR(ENOMEM);
         goto err;
     }
     input.data = (float *)TF_TensorData(infer_request->input_tensor);
@@ -1034,12 +1041,14 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     infer_request->tf_outputs = av_malloc_array(task->nb_output, sizeof(TF_Output));
     if (infer_request->tf_outputs == NULL) {
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for *tf_outputs\n");
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
     infer_request->output_tensors = av_calloc(task->nb_output, sizeof(*infer_request->output_tensors));
     if (!infer_request->output_tensors) {
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate memory for output tensor\n");
+        ret = AVERROR(ENOMEM);
         goto err;
     }
 
@@ -1048,6 +1057,7 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
         infer_request->tf_outputs[i].oper = TF_GraphOperationByName(tf_model->graph, task->output_names[i]);
         if (!infer_request->tf_outputs[i].oper) {
             av_log(ctx, AV_LOG_ERROR, "Could not find output \"%s\" in model\n", task->output_names[i]);
+            ret = DNN_GENERIC_ERROR;
             goto err;
         }
         infer_request->tf_outputs[i].index = 0;
@@ -1056,7 +1066,7 @@ static DNNReturnType fill_model_input_tf(TFModel *tf_model, TFRequestItem *reque
     return DNN_SUCCESS;
 err:
     tf_free_request(infer_request);
-    return DNN_ERROR;
+    return ret;
 }
 
 static void infer_completion_callback(void *args) {
@@ -1135,12 +1145,13 @@ err:
     }
 }
 
-static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *lltask_queue)
+static int execute_model_tf(TFRequestItem *request, Queue *lltask_queue)
 {
     TFModel *tf_model;
     TFContext *ctx;
     LastLevelTaskItem *lltask;
     TaskItem *task;
+    int ret = 0;
 
     if (ff_queue_size(lltask_queue) == 0) {
         destroy_request_item(&request);
@@ -1152,7 +1163,8 @@ static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *lltask_queu
     tf_model = task->model;
     ctx = &tf_model->ctx;
 
-    if (fill_model_input_tf(tf_model, request) != DNN_SUCCESS) {
+    ret = fill_model_input_tf(tf_model, request);
+    if (ret != DNN_SUCCESS) {
         goto err;
     }
 
@@ -1161,63 +1173,70 @@ static DNNReturnType execute_model_tf(TFRequestItem *request, Queue *lltask_queu
             goto err;
         }
         return DNN_SUCCESS;
-    } else {
-        if (tf_start_inference(request) != DNN_SUCCESS) {
+    }
+    else {
+        ret = tf_start_inference(request);
+        if (ret != DNN_SUCCESS) {
             goto err;
         }
         infer_completion_callback(request);
-        return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_ERROR;
+        return (task->inference_done == task->inference_todo) ? DNN_SUCCESS : DNN_GENERIC_ERROR;
     }
 err:
     tf_free_request(request->infer_request);
     if (ff_safe_queue_push_back(tf_model->request_queue, request) < 0) {
         destroy_request_item(&request);
     }
-    return DNN_ERROR;
+    return ret;
 }
 
-DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params)
+int ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params)
 {
     TFModel *tf_model = model->model;
     TFContext *ctx = &tf_model->ctx;
     TaskItem *task;
     TFRequestItem *request;
+    int ret = 0;
 
-    if (ff_check_exec_params(ctx, DNN_TF, model->func_type, exec_params) != 0) {
-        return DNN_ERROR;
+    ret = ff_check_exec_params(ctx, DNN_TF, model->func_type, exec_params);
+    if (ret != 0) {
+        return ret;
     }
 
     task = av_malloc(sizeof(*task));
     if (!task) {
         av_log(ctx, AV_LOG_ERROR, "unable to alloc memory for task item.\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
-    if (ff_dnn_fill_task(task, exec_params, tf_model, ctx->options.async, 1) != DNN_SUCCESS) {
+    ret = ff_dnn_fill_task(task, exec_params, tf_model, ctx->options.async, 1);
+    if (ret != DNN_SUCCESS) {
         av_freep(&task);
-        return DNN_ERROR;
+        return ret;
     }
 
     if (ff_queue_push_back(tf_model->task_queue, task) < 0) {
         av_freep(&task);
         av_log(ctx, AV_LOG_ERROR, "unable to push back task_queue.\n");
-        return DNN_ERROR;
+        return AVERROR(ENOMEM);
     }
 
-    if (extract_lltask_from_task(task, tf_model->lltask_queue) != DNN_SUCCESS) {
+    ret = extract_lltask_from_task(task, tf_model->lltask_queue);
+    if (ret != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "unable to extract last level task from task.\n");
-        return DNN_ERROR;
+        return ret;
     }
 
     while (ff_queue_size(tf_model->lltask_queue) >= ctx->options.batch_size) {
         request = ff_safe_queue_pop_front(tf_model->request_queue);
         if (!request) {
             av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
 
-        if (execute_model_tf(request, tf_model->lltask_queue) != DNN_SUCCESS) {
-            return DNN_ERROR;
+        ret = execute_model_tf(request, tf_model->lltask_queue);
+        if (ret != DNN_SUCCESS) {
+            return ret;
         }
     }
     return DNN_SUCCESS;
@@ -1229,12 +1248,12 @@ DNNAsyncStatusType ff_dnn_get_result_tf(const DNNModel *model, AVFrame **in, AVF
     return ff_dnn_get_result_common(tf_model->task_queue, in, out);
 }
 
-DNNReturnType ff_dnn_flush_tf(const DNNModel *model)
+int ff_dnn_flush_tf(const DNNModel *model)
 {
     TFModel *tf_model = model->model;
     TFContext *ctx = &tf_model->ctx;
     TFRequestItem *request;
-    DNNReturnType ret;
+    int ret;
 
     if (ff_queue_size(tf_model->lltask_queue) == 0) {
         // no pending task need to flush
@@ -1244,7 +1263,7 @@ DNNReturnType ff_dnn_flush_tf(const DNNModel *model)
     request = ff_safe_queue_pop_front(tf_model->request_queue);
     if (!request) {
         av_log(ctx, AV_LOG_ERROR, "unable to get infer request.\n");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     ret = fill_model_input_tf(tf_model, request);

--- a/libavfilter/dnn/dnn_backend_tf.h
+++ b/libavfilter/dnn/dnn_backend_tf.h
@@ -31,9 +31,9 @@
 
 DNNModel *ff_dnn_load_model_tf(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
 
-DNNReturnType ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
+int ff_dnn_execute_model_tf(const DNNModel *model, DNNExecBaseParams *exec_params);
 DNNAsyncStatusType ff_dnn_get_result_tf(const DNNModel *model, AVFrame **in, AVFrame **out);
-DNNReturnType ff_dnn_flush_tf(const DNNModel *model);
+int ff_dnn_flush_tf(const DNNModel *model);
 
 void ff_dnn_free_model_tf(DNNModel **model);
 

--- a/libavfilter/dnn/dnn_io_proc.c
+++ b/libavfilter/dnn/dnn_io_proc.c
@@ -24,16 +24,16 @@
 #include "libavutil/avassert.h"
 #include "libavutil/detection_bbox.h"
 
-DNNReturnType ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *log_ctx)
+int ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *log_ctx)
 {
     struct SwsContext *sws_ctx;
     int bytewidth = av_image_get_linesize(frame->format, frame->width, 0);
     if (bytewidth < 0) {
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     if (output->dt != DNN_FLOAT) {
         avpriv_report_missing_feature(log_ctx, "data type rather than DNN_FLOAT");
-        return DNN_ERROR;
+        return AVERROR(ENOSYS);
     }
 
     switch (frame->format) {
@@ -51,7 +51,7 @@ DNNReturnType ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *l
                 "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAYF32), frame->width * 3, frame->height,
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAY8),   frame->width * 3, frame->height);
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         sws_scale(sws_ctx, (const uint8_t *[4]){(const uint8_t *)output->data, 0, 0, 0},
                            (const int[4]){frame->width * 3 * sizeof(float), 0, 0, 0}, 0, frame->height,
@@ -82,7 +82,7 @@ DNNReturnType ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *l
                 "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAYF32), frame->width, frame->height,
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAY8),   frame->width, frame->height);
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         sws_scale(sws_ctx, (const uint8_t *[4]){(const uint8_t *)output->data, 0, 0, 0},
                            (const int[4]){frame->width * sizeof(float), 0, 0, 0}, 0, frame->height,
@@ -91,22 +91,22 @@ DNNReturnType ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *l
         return DNN_SUCCESS;
     default:
         avpriv_report_missing_feature(log_ctx, "%s", av_get_pix_fmt_name(frame->format));
-        return DNN_ERROR;
+        return AVERROR(ENOSYS);
     }
 
     return DNN_SUCCESS;
 }
 
-DNNReturnType ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *log_ctx)
+int ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *log_ctx)
 {
     struct SwsContext *sws_ctx;
     int bytewidth = av_image_get_linesize(frame->format, frame->width, 0);
     if (bytewidth < 0) {
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
     if (input->dt != DNN_FLOAT) {
         avpriv_report_missing_feature(log_ctx, "data type rather than DNN_FLOAT");
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
     switch (frame->format) {
@@ -124,7 +124,7 @@ DNNReturnType ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *lo
                 "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAY8),  frame->width * 3, frame->height,
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAYF32),frame->width * 3, frame->height);
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         sws_scale(sws_ctx, (const uint8_t **)frame->data,
                            frame->linesize, 0, frame->height,
@@ -156,7 +156,7 @@ DNNReturnType ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *lo
                 "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAY8),  frame->width, frame->height,
                 av_get_pix_fmt_name(AV_PIX_FMT_GRAYF32),frame->width, frame->height);
-            return DNN_ERROR;
+            return AVERROR(EINVAL);
         }
         sws_scale(sws_ctx, (const uint8_t **)frame->data,
                            frame->linesize, 0, frame->height,
@@ -166,7 +166,7 @@ DNNReturnType ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *lo
         break;
     default:
         avpriv_report_missing_feature(log_ctx, "%s", av_get_pix_fmt_name(frame->format));
-        return DNN_ERROR;
+        return AVERROR(ENOSYS);
     }
 
     return DNN_SUCCESS;
@@ -190,13 +190,14 @@ static enum AVPixelFormat get_pixel_format(DNNData *data)
     return AV_PIX_FMT_BGR24;
 }
 
-DNNReturnType ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t bbox_index, void *log_ctx)
+int ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t bbox_index, void *log_ctx)
 {
     const AVPixFmtDescriptor *desc;
     int offsetx[4], offsety[4];
     uint8_t *bbox_data[4];
     struct SwsContext *sws_ctx;
     int linesizes[4];
+    int ret = DNN_SUCCESS;
     enum AVPixelFormat fmt;
     int left, top, width, height;
     const AVDetectionBBoxHeader *header;
@@ -221,13 +222,14 @@ DNNReturnType ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t 
                "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
                av_get_pix_fmt_name(frame->format), width, height,
                av_get_pix_fmt_name(fmt), input->width, input->height);
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
-    if (av_image_fill_linesizes(linesizes, fmt, input->width) < 0) {
+    ret = av_image_fill_linesizes(linesizes, fmt, input->width);
+    if (ret < 0) {
         av_log(log_ctx, AV_LOG_ERROR, "unable to get linesizes with av_image_fill_linesizes");
         sws_freeContext(sws_ctx);
-        return DNN_ERROR;
+        return ret;
     }
 
     desc = av_pix_fmt_desc_get(frame->format);
@@ -246,13 +248,14 @@ DNNReturnType ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t 
 
     sws_freeContext(sws_ctx);
 
-    return DNN_SUCCESS;
+    return ret;
 }
 
-DNNReturnType ff_frame_to_dnn_detect(AVFrame *frame, DNNData *input, void *log_ctx)
+int ff_frame_to_dnn_detect(AVFrame *frame, DNNData *input, void *log_ctx)
 {
     struct SwsContext *sws_ctx;
     int linesizes[4];
+    int ret = DNN_SUCCESS;
     enum AVPixelFormat fmt = get_pixel_format(input);
     sws_ctx = sws_getContext(frame->width, frame->height, frame->format,
                              input->width, input->height, fmt,
@@ -262,18 +265,19 @@ DNNReturnType ff_frame_to_dnn_detect(AVFrame *frame, DNNData *input, void *log_c
             "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
             av_get_pix_fmt_name(frame->format), frame->width, frame->height,
             av_get_pix_fmt_name(fmt), input->width, input->height);
-        return DNN_ERROR;
+        return AVERROR(EINVAL);
     }
 
-    if (av_image_fill_linesizes(linesizes, fmt, input->width) < 0) {
+    ret = av_image_fill_linesizes(linesizes, fmt, input->width);
+    if (ret < 0) {
         av_log(log_ctx, AV_LOG_ERROR, "unable to get linesizes with av_image_fill_linesizes");
         sws_freeContext(sws_ctx);
-        return DNN_ERROR;
+        return ret;
     }
 
     sws_scale(sws_ctx, (const uint8_t *const *)frame->data, frame->linesize, 0, frame->height,
                        (uint8_t *const [4]){input->data, 0, 0, 0}, linesizes);
 
     sws_freeContext(sws_ctx);
-    return DNN_SUCCESS;
+    return ret;
 }

--- a/libavfilter/dnn/dnn_io_proc.h
+++ b/libavfilter/dnn/dnn_io_proc.h
@@ -30,9 +30,9 @@
 #include "../dnn_interface.h"
 #include "libavutil/frame.h"
 
-DNNReturnType ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *log_ctx);
-DNNReturnType ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *log_ctx);
-DNNReturnType ff_frame_to_dnn_detect(AVFrame *frame, DNNData *input, void *log_ctx);
-DNNReturnType ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t bbox_index, void *log_ctx);
+int ff_proc_from_frame_to_dnn(AVFrame *frame, DNNData *input, void *log_ctx);
+int ff_proc_from_dnn_to_frame(AVFrame *frame, DNNData *output, void *log_ctx);
+int ff_frame_to_dnn_detect(AVFrame *frame, DNNData *input, void *log_ctx);
+int ff_frame_to_dnn_classify(AVFrame *frame, DNNData *input, uint32_t bbox_index, void *log_ctx);
 
 #endif

--- a/libavfilter/dnn_filter_common.c
+++ b/libavfilter/dnn_filter_common.c
@@ -106,18 +106,18 @@ int ff_dnn_set_classify_post_proc(DnnContext *ctx, ClassifyPostProc post_proc)
     return 0;
 }
 
-DNNReturnType ff_dnn_get_input(DnnContext *ctx, DNNData *input)
+int ff_dnn_get_input(DnnContext *ctx, DNNData *input)
 {
     return ctx->model->get_input(ctx->model->model, input, ctx->model_inputname);
 }
 
-DNNReturnType ff_dnn_get_output(DnnContext *ctx, int input_width, int input_height, int *output_width, int *output_height)
+int ff_dnn_get_output(DnnContext *ctx, int input_width, int input_height, int *output_width, int *output_height)
 {
     return ctx->model->get_output(ctx->model->model, ctx->model_inputname, input_width, input_height,
                                     (const char *)ctx->model_outputnames[0], output_width, output_height);
 }
 
-DNNReturnType ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame)
+int ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame)
 {
     DNNExecBaseParams exec_params = {
         .input_name     = ctx->model_inputname,
@@ -129,7 +129,7 @@ DNNReturnType ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *
     return (ctx->dnn_module->execute_model)(ctx->model, &exec_params);
 }
 
-DNNReturnType ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target)
+int ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target)
 {
     DNNExecClassificationParams class_params = {
         {
@@ -149,7 +149,7 @@ DNNAsyncStatusType ff_dnn_get_result(DnnContext *ctx, AVFrame **in_frame, AVFram
     return (ctx->dnn_module->get_result)(ctx->model, in_frame, out_frame);
 }
 
-DNNReturnType ff_dnn_flush(DnnContext *ctx)
+int ff_dnn_flush(DnnContext *ctx)
 {
     return (ctx->dnn_module->flush)(ctx->model);
 }

--- a/libavfilter/dnn_filter_common.h
+++ b/libavfilter/dnn_filter_common.h
@@ -53,12 +53,12 @@ int ff_dnn_init(DnnContext *ctx, DNNFunctionType func_type, AVFilterContext *fil
 int ff_dnn_set_frame_proc(DnnContext *ctx, FramePrePostProc pre_proc, FramePrePostProc post_proc);
 int ff_dnn_set_detect_post_proc(DnnContext *ctx, DetectPostProc post_proc);
 int ff_dnn_set_classify_post_proc(DnnContext *ctx, ClassifyPostProc post_proc);
-DNNReturnType ff_dnn_get_input(DnnContext *ctx, DNNData *input);
-DNNReturnType ff_dnn_get_output(DnnContext *ctx, int input_width, int input_height, int *output_width, int *output_height);
-DNNReturnType ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame);
-DNNReturnType ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target);
+int ff_dnn_get_input(DnnContext *ctx, DNNData *input);
+int ff_dnn_get_output(DnnContext *ctx, int input_width, int input_height, int *output_width, int *output_height);
+int ff_dnn_execute_model(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame);
+int ff_dnn_execute_model_classification(DnnContext *ctx, AVFrame *in_frame, AVFrame *out_frame, const char *target);
 DNNAsyncStatusType ff_dnn_get_result(DnnContext *ctx, AVFrame **in_frame, AVFrame **out_frame);
-DNNReturnType ff_dnn_flush(DnnContext *ctx);
+int ff_dnn_flush(DnnContext *ctx);
 void ff_dnn_uninit(DnnContext *ctx);
 
 #endif

--- a/libavfilter/dnn_interface.h
+++ b/libavfilter/dnn_interface.h
@@ -30,6 +30,8 @@
 #include "libavutil/frame.h"
 #include "avfilter.h"
 
+#define DNN_GENERIC_ERROR FFERRTAG('D','N','N','!')
+
 typedef enum {DNN_SUCCESS, DNN_ERROR} DNNReturnType;
 
 typedef enum {DNN_NATIVE, DNN_TF, DNN_OV} DNNBackendType;

--- a/libavfilter/dnn_interface.h
+++ b/libavfilter/dnn_interface.h
@@ -94,9 +94,9 @@ typedef struct DNNModel{
     DNNFunctionType func_type;
     // Gets model input information
     // Just reuse struct DNNData here, actually the DNNData.data field is not needed.
-    DNNReturnType (*get_input)(void *model, DNNData *input, const char *input_name);
+    int (*get_input)(void *model, DNNData *input, const char *input_name);
     // Gets model output width/height with given input w/h
-    DNNReturnType (*get_output)(void *model, const char *input_name, int input_width, int input_height,
+    int (*get_output)(void *model, const char *input_name, int input_width, int input_height,
                                 const char *output_name, int *output_width, int *output_height);
     // set the pre process to transfer data from AVFrame to DNNData
     // the default implementation within DNN is used if it is not provided by the filter
@@ -115,11 +115,11 @@ typedef struct DNNModule{
     // Loads model and parameters from given file. Returns NULL if it is not possible.
     DNNModel *(*load_model)(const char *model_filename, DNNFunctionType func_type, const char *options, AVFilterContext *filter_ctx);
     // Executes model with specified input and output. Returns DNN_ERROR otherwise.
-    DNNReturnType (*execute_model)(const DNNModel *model, DNNExecBaseParams *exec_params);
+    int (*execute_model)(const DNNModel *model, DNNExecBaseParams *exec_params);
     // Retrieve inference result.
     DNNAsyncStatusType (*get_result)(const DNNModel *model, AVFrame **in, AVFrame **out);
     // Flush all the pending tasks.
-    DNNReturnType (*flush)(const DNNModel *model);
+    int (*flush)(const DNNModel *model);
     // Frees memory allocated for model.
     void (*free_model)(DNNModel **model);
 } DNNModule;

--- a/libavfilter/vf_derain.c
+++ b/libavfilter/vf_derain.c
@@ -62,7 +62,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
     AVFilterContext *ctx  = inlink->dst;
     AVFilterLink *outlink = ctx->outputs[0];
     DRContext *dr_context = ctx->priv;
-    DNNReturnType dnn_result;
+    int dnn_result;
     AVFrame *out;
 
     out = ff_get_video_buffer(outlink, outlink->w, outlink->h);
@@ -77,7 +77,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
     if (dnn_result != DNN_SUCCESS){
         av_log(ctx, AV_LOG_ERROR, "failed to execute model\n");
         av_frame_free(&in);
-        return AVERROR(EIO);
+        return dnn_result;
     }
     do {
         async_state = ff_dnn_get_result(&dr_context->dnnctx, &in, &out);

--- a/libavfilter/vf_dnn_processing.c
+++ b/libavfilter/vf_dnn_processing.c
@@ -134,14 +134,14 @@ static int config_input(AVFilterLink *inlink)
 {
     AVFilterContext *context     = inlink->dst;
     DnnProcessingContext *ctx = context->priv;
-    DNNReturnType result;
+    int result;
     DNNData model_input;
     int check;
 
     result = ff_dnn_get_input(&ctx->dnnctx, &model_input);
     if (result != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "could not get input from the model\n");
-        return AVERROR(EIO);
+        return result;
     }
 
     check = check_modelinput_inlink(&model_input, inlink);
@@ -194,14 +194,14 @@ static int config_output(AVFilterLink *outlink)
 {
     AVFilterContext *context = outlink->src;
     DnnProcessingContext *ctx = context->priv;
-    DNNReturnType result;
+    int result;
     AVFilterLink *inlink = context->inputs[0];
 
     // have a try run in case that the dnn model resize the frame
     result = ff_dnn_get_output(&ctx->dnnctx, inlink->w, inlink->h, &outlink->w, &outlink->h);
     if (result != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "could not get output from the model\n");
-        return AVERROR(EIO);
+        return result;
     }
 
     prepare_uv_scale(outlink);

--- a/libavfilter/vf_sr.c
+++ b/libavfilter/vf_sr.c
@@ -76,7 +76,7 @@ static int config_output(AVFilterLink *outlink)
 {
     AVFilterContext *context = outlink->src;
     SRContext *ctx = context->priv;
-    DNNReturnType result;
+    int result;
     AVFilterLink *inlink = context->inputs[0];
     int out_width, out_height;
 
@@ -84,7 +84,7 @@ static int config_output(AVFilterLink *outlink)
     result = ff_dnn_get_output(&ctx->dnnctx, inlink->w, inlink->h, &out_width, &out_height);
     if (result != DNN_SUCCESS) {
         av_log(ctx, AV_LOG_ERROR, "could not get output from the model\n");
-        return AVERROR(EIO);
+        return result;
     }
 
     if (inlink->w != out_width || inlink->h != out_height) {
@@ -121,7 +121,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
     SRContext *ctx = context->priv;
     AVFilterLink *outlink = context->outputs[0];
     AVFrame *out = ff_get_video_buffer(outlink, outlink->w, outlink->h);
-    DNNReturnType dnn_result;
+    int dnn_result;
 
     if (!out){
         av_log(context, AV_LOG_ERROR, "could not allocate memory for output frame\n");
@@ -143,7 +143,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
         av_log(ctx, AV_LOG_ERROR, "failed to execute loaded model\n");
         av_frame_free(&in);
         av_frame_free(&out);
-        return AVERROR(EIO);
+        return dnn_result;
     }
 
     do {


### PR DESCRIPTION
## Patch Set Description

This patchset improves the error specificity on all the patchsets from the GSoC project [Async Support for TensorFlow Backend in FFmpeg](https://summerofcode.withgoogle.com/projects/#5224576843251712).

- Builds on the patchset from PR #423, #425, and #427

**Objective**: Return Specific Error codes from the DNN Backend Functions

### Parts under this deliverable

- Add `DNN_GENERIC_ERROR` for errors related to the backend framework API-related errors.
- Use error codes from [libavutil/error.c](libavutil/error.c)

### Patches

41b15128ede7a041e51fc8de15735c79cab79e2c libavfilter: Prepare to handle specific error codes in DNN Filters
9f53605b93bf4cbc39b9a794cec64c1063d46cc8 lavfi/dnn: Error Specificity in Native Backend Layers
c3a2fe2ddb34ab4ff5ec00543bd03dbe50dd71a6 lavfi/dnn_io_proc: Return Specific Error Codes
9e219b76e2d745c937fbfff24810544ef68691b6 lavfi/dnn_backend_openvino: Return Specific Error Codes
4a498acbc4abd8092dff69e77b5fbff6b07159bc lavfi/dnn_backend_tf: Return Specific Error Codes
ec471f77dcc0f3b5fa34d71b328817a7ee9a505b lavfi/dnn_backend_native: Return Specific Error Codes
605cccb76e1087d6ee4611886cc7e3d77cf03ce3 lavfi/dnn_backend_common: Return specific error codes
