### PR TITLE
avcodec/av1dec: modify error log

### DIFF
--- a/libavcodec/av1dec.c
+++ b/libavcodec/av1dec.c
@@ -462,8 +462,8 @@ static int get_pixel_format(AVCodecContext *avctx)
      * implemented in the future, need remove this check.
      */
     if (!avctx->hwaccel) {
-        av_log(avctx, AV_LOG_ERROR, "Your platform doesn't suppport"
-               " hardware accelerated AV1 decoding.\n");
+        av_log(avctx, AV_LOG_ERROR, "The AV1 decoder requires a hw acceleration"
+               " to be specified or the specified hw doesn't support AV1 decoding.\n");
         return AVERROR(ENOSYS);
     }
 


### PR DESCRIPTION
This will gives out more accurate information in case of this
decoder used but doesn't specificed a hwaccel.

For example:
ffmpeg -c:v av1 -i INPUT OUTPUT

Signed-off-by: Fei Wang <fei.w.wang@intel.com>