### PR TITLE
libavcodec/hevc_mp4toannexb_bsf: ignore extra data if possible

### DIFF
--- a/libavcodec/hevc_mp4toannexb_bsf.c
+++ b/libavcodec/hevc_mp4toannexb_bsf.c
@@ -121,7 +121,7 @@ static int hevc_mp4toannexb_filter(AVBSFContext *ctx, AVPacket *out)
     HEVCBSFContext *s = ctx->priv_data;
     AVPacket *in;
     GetByteContext gb;
-
+    int has_sps = 0, has_pps = 0;
     int got_irap = 0;
     int i, ret = 0;
 
@@ -155,10 +155,13 @@ static int hevc_mp4toannexb_filter(AVBSFContext *ctx, AVPacket *out)
         }
 
         nalu_type = (bytestream2_peek_byte(&gb) >> 1) & 0x3f;
+        has_sps = (has_sps || nalu_type == HEVC_NAL_SPS);
+        has_pps = (has_pps || nalu_type == HEVC_NAL_PPS);
 
         /* prepend extradata to IRAP frames */
         is_irap       = nalu_type >= 16 && nalu_type <= 23;
-        add_extradata = is_irap && !got_irap;
+        /* ignore the extradata if IRAP frame has sps and pps */
+        add_extradata = is_irap && !got_irap && !(has_sps && has_pps);
         extra_size    = add_extradata * ctx->par_out->extradata_size;
         got_irap     |= is_irap;
 

--- a/tests/fate/hevc.mak
+++ b/tests/fate/hevc.mak
@@ -251,7 +251,7 @@ FATE_HEVC-$(call ALLYES, HEVC_DEMUXER MOV_DEMUXER HEVC_MP4TOANNEXB_BSF MOV_MUXER
 fate-hevc-bsf-mp4toannexb: tests/data/hevc-mp4.mov
 fate-hevc-bsf-mp4toannexb: CMD = md5 -i $(TARGET_PATH)/tests/data/hevc-mp4.mov -c:v copy -fflags +bitexact -f hevc
 fate-hevc-bsf-mp4toannexb: CMP = oneline
-fate-hevc-bsf-mp4toannexb: REF = 1873662a3af1848c37e4eb25722c8df9
+fate-hevc-bsf-mp4toannexb: REF = 3c9d998a3aa2b9e0fb1c1f434952bf8b
 
 fate-hevc-skiploopfilter: CMD = framemd5 -skip_loop_filter nokey -i $(TARGET_SAMPLES)/hevc-conformance/SAO_D_Samsung_5.bit -sws_flags bitexact
 FATE_HEVC += fate-hevc-skiploopfilter


### PR DESCRIPTION
It is possible that an IRAP frame in in-AVPacket has VPS, SPS and PPS,
and these headere should take effect in out-AVPacket, so we should not
prepend extradata to IRAP frame in this case, otherwise an IRAP frame in
out-AVPcket might have 2 VPS/SPS/PPS if extradata has VPS, SPS and PPS,
the second VPS/SPS/PPS will take effect