### PR TITLE
libavfilter/vf_vpp_qsv: fix uninitialized variable problem

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -501,8 +501,8 @@ static int activate(AVFilterContext *ctx)
     VPPContext *s =ctx->priv;
     QSVVPPContext *qsv = s->qsv;
     AVFrame *in = NULL;
-    int ret, status;
-    int64_t pts;
+    int ret, status = 0;
+    int64_t pts = AV_NOPTS_VALUE;
 
     FF_FILTER_FORWARD_STATUS_BACK(outlink, inlink);
 


### PR DESCRIPTION
This two variables may be used below with uninitialized value.
Now fix them.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>