### PR TITLE
hwcontext_qsv/opencl: fix two bugs regarding frame mapping to/from qsv

### DIFF
--- a/libavutil/hwcontext_opencl.c
+++ b/libavutil/hwcontext_opencl.c
@@ -2249,7 +2249,8 @@ static int opencl_map_from_qsv(AVHWFramesContext *dst_fc, AVFrame *dst,
 #if CONFIG_LIBMFX
     if (src->format == AV_PIX_FMT_QSV) {
         mfxFrameSurface1 *mfx_surface = (mfxFrameSurface1*)src->data[3];
-        va_surface = *(VASurfaceID*)mfx_surface->Data.MemId;
+        mfxHDLPair *pair = (mfxHDLPair*)mfx_surface->Data.MemId;
+        va_surface = *(VASurfaceID*)pair->first;
     } else
 #endif
         if (src->format == AV_PIX_FMT_VAAPI) {

--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -1220,7 +1220,7 @@ static int qsv_map_to(AVHWFramesContext *dst_ctx,
         case AV_PIX_FMT_VAAPI:
         {
             mfxHDLPair *pair = (mfxHDLPair*)hwctx->surfaces[i].Data.MemId;
-            if (pair->first == src->data[3]) {
+            if (*(VASurfaceID*)pair->first == (VASurfaceID)src->data[3]) {
                 index = i;
                 break;
             }


### PR DESCRIPTION
They were introduced in the qsv d3d11 patch series merged by upstream last month.

Mapping from qsv to vaapi has been fixed by https://github.com/FFmpeg/FFmpeg/commit/f2891fbdeddd9049ba03b600d6c93a1ab732df66


First CLI: (Note that without https://github.com/intel-media-ci/ffmpeg/pull/451, a dummy `scale_vaapi` must be added before `hwmap=derive_device=qsv`)
```
ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 \
-hwaccel vaapi -hwaccel_output_format vaapi \
-i 1080P.264 -vf "hwmap=derive_device=qsv,format=qsv" -c:v h264_qsv output.264 \
```

Second CLI:
```
ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 \
-init_hw_device qsv=qs@va -init_hw_device opencl=ocl@va -filter_hw_device ocl \
-hwaccel qsv -hwaccel_output_format qsv -hwaccel_device qs \
-c:v h264_qsv -i 1080P.264 \
-vf "hwmap=derive_device=opencl,format=opencl,avgblur_opencl,hwmap=derive_device=qsv:reverse=1:extra_hw_frames=32,format=qsv" \
-c:v h264_qsv output.264 \
```