### PR TITLE
libavfilter/vf_overlay_qsv: Add an option to choose output format

### DIFF
--- a/libavfilter/vf_overlay_qsv.c
+++ b/libavfilter/vf_overlay_qsv.c
@@ -276,6 +276,7 @@ static int config_output(AVFilterLink *outlink)
     int ret;
 
     av_log(ctx, AV_LOG_DEBUG, "Output is of %s.\n", av_get_pix_fmt_name(outlink->format));
+    vpp->qsv_param.out_sw_format = in0->format;
     if ((in0->format == AV_PIX_FMT_QSV && in1->format != AV_PIX_FMT_QSV) ||
         (in0->format != AV_PIX_FMT_QSV && in1->format == AV_PIX_FMT_QSV)) {
         av_log(ctx, AV_LOG_ERROR, "Mixing hardware and software pixel formats is not supported.\n");
@@ -288,6 +289,7 @@ static int config_output(AVFilterLink *outlink)
             av_log(ctx, AV_LOG_ERROR, "Inputs with different underlying QSV devices are forbidden.\n");
             return AVERROR(EINVAL);
         }
+        vpp->qsv_param.out_sw_format = hw_frame0->sw_format;
     }
 
     outlink->w          = vpp->var_values[VAR_MW];


### PR DESCRIPTION
overlay_qsv hard coded to use nv12 as output format. An new option
"format" is added to set output format. Now we can choose different
output format. For example, we can output 10bit as follow:

ffmpeg -hwaccel qsv -c:v h264_qsv -i input.264 -hwaccel qsv -c:v hevc_qsv \
-i input.265 -filter_complex "[0:v][1:v]overlay_qsv=x=0:y=0:alpha=255: \
format=p010,hwdownload,format=p010le" -f rawvideo -y output_p010.yuv

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>