### PR TITLE
lavc/av1dec: use frame split bsf

### DIFF
--- a/libavcodec/av1dec.c
+++ b/libavcodec/av1dec.c
@@ -1240,6 +1240,7 @@ const AVCodec ff_av1_decoder = {
     .flush                 = av1_decode_flush,
     .profiles              = NULL_IF_CONFIG_SMALL(ff_av1_profiles),
     .priv_class            = &av1_class,
+    .bsfs                  = "av1_frame_split",
     .hw_configs            = (const AVCodecHWConfigInternal *const []) {
 #if CONFIG_AV1_DXVA2_HWACCEL
         HWACCEL_DXVA2(av1),


### PR DESCRIPTION
Split packed data in case of its contains multiple show frame in some
non-standard bitstream. This can benefit decoder which can decode
continuously instead of interrupt with unexpected error.

Signed-off-by: Fei Wang <fei.w.wang@intel.com>