### PR TITLE
lavc/qsvenc: add tile encoding support for VP9

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -793,6 +793,10 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
         q->extvp9param.Header.BufferId = MFX_EXTBUFF_VP9_PARAM;
         q->extvp9param.Header.BufferSz = sizeof(q->extvp9param);
         q->extvp9param.WriteIVFHeaders = MFX_CODINGOPTION_OFF;
+#if (MFX_VERSION >= 1029)
+        q->extvp9param.NumTileColumns  = q->tile_cols;
+        q->extvp9param.NumTileRows     = q->tile_rows;
+#endif
         q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extvp9param;
     }
 #endif

--- a/libavcodec/qsvenc_vp9.c
+++ b/libavcodec/qsvenc_vp9.c
@@ -73,6 +73,16 @@ static const AVOption options[] = {
     { "profile2",  NULL, 0,                   AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_VP9_2   },  INT_MIN,  INT_MAX,  VE,  "profile" },
     { "profile3",  NULL, 0,                   AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_VP9_3   },  INT_MIN,  INT_MAX,  VE,  "profile" },
 
+#if (MFX_VERSION >= 1029)
+    /* The minimum tile width in luma pixels is 256, set maximum tile_cols to 32 for 8K video */
+    { "tile_cols",  "Number of columns for tiled encoding",   OFFSET(qsv.tile_cols),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 32, VE },
+    /* Set maximum tile_rows to 4 per VP9 spec */
+    { "tile_rows",  "Number of rows for tiled encoding",      OFFSET(qsv.tile_rows),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 4, VE },
+#else
+    { "tile_cols",  "(not supported)",                        OFFSET(qsv.tile_cols),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0, VE },
+    { "tile_rows",  "(not supported)",                        OFFSET(qsv.tile_rows),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0, VE },
+#endif
+
     { NULL },
 };
 


### PR DESCRIPTION
Add -tile_rows and -tile_cols options to specify the number of tile
rows and and columns