### PR TITLE
libavcodec/qsvenc: fix a memory leak problem

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1521,6 +1521,7 @@ static int submit_frame(QSVEncContext *q, const AVFrame *frame,
                 return ret;
             }
         } else {
+            av_frame_unref(qf->frame);
             ret = av_frame_ref(qf->frame, frame);
             if (ret < 0)
                 return ret;


### PR DESCRIPTION
"qf->frame" ref to input frame but it isn't released. av_frame_unref()
is added before refering qf->frame to new frame to make sure the previous
reference is released.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>