### PR TITLE
Add AVX512 Icelake flag

### DIFF
--- a/libavcodec/x86/hevc_mc.asm
+++ b/libavcodec/x86/hevc_mc.asm
@@ -87,6 +87,7 @@ QPEL_TABLE 12, 4, w, sse4
 QPEL_TABLE  8,16, b, avx2
 QPEL_TABLE 10, 8, w, avx2
 
+QPEL_TABLE  4, 1, b, avx512icl_h
 QPEL_TABLE  8, 1, b, avx512icl_h
 QPEL_TABLE  8, 1, d, avx512icl_v
 QPEL_TABLE 16, 1, b, avx512icl_h
@@ -1754,7 +1755,12 @@ cglobal hevc_put_hevc_qpel_h%1_%2, 5, 6, 8, dst, src, srcstride, height, mx, tmp
     QPEL_LOAD_SHUF   2, 3
 .loop:
     QPEL_H_LOAD_COMPUTE   6, src
+%if %1 == 4
+    vpmovdw             xm6, m6
+    movq             [dstq], xm6
+%else
     vpmovdw          [dstq], m6
+%endif
     LOOP_END            dst, src, srcstride
     RET
 %endmacro
@@ -1821,6 +1827,9 @@ cglobal hevc_put_hevc_qpel_hv%1_%2, 6, 7, 27, dst, src, srcstride, height, mx, m
 
 %if ARCH_X86_64
 %if HAVE_AVX512ICL_EXTERNAL
+
+INIT_XMM avx512icl
+HEVC_PUT_HEVC_QPEL_AVX512ICL 4, 8
 
 INIT_YMM avx512icl
 HEVC_PUT_HEVC_QPEL_AVX512ICL 8, 8

--- a/libavcodec/x86/hevc_mc.asm
+++ b/libavcodec/x86/hevc_mc.asm
@@ -92,6 +92,7 @@ QPEL_TABLE  8, 1, b, avx512icl_h
 QPEL_TABLE  8, 1, d, avx512icl_v
 QPEL_TABLE 16, 1, b, avx512icl_h
 QPEL_TABLE 32, 1, b, avx512icl_h
+QPEL_TABLE 64, 1, b, avx512icl_h
 
 pb_qpel_shuffle_index: db  0,  1,  2,  3
                        db  1,  2,  3,  4
@@ -1767,9 +1768,15 @@ cglobal hevc_put_hevc_qpel_h%1_%2, 5, 6, 8, dst, src, srcstride, height, mx, tmp
 %else
     vpmovdw          [dstq], m6
 %endif
-%if %1 == 32
+%if %1 > 16
     QPEL_H_LOAD_COMPUTE   7, src, 16
     vpmovdw     [dstq + 32], m7
+%endif
+%if %1 > 32
+    QPEL_H_LOAD_COMPUTE   6, src, 32
+    QPEL_H_LOAD_COMPUTE   7, src, 48
+    vpmovdw     [dstq + 64], m6
+    vpmovdw     [dstq + 96], m7
 %endif
     LOOP_END            dst, src, srcstride
     RET
@@ -1848,6 +1855,7 @@ HEVC_PUT_HEVC_QPEL_HV_AVX512ICL 8, 8
 INIT_ZMM avx512icl
 HEVC_PUT_HEVC_QPEL_AVX512ICL 16, 8
 HEVC_PUT_HEVC_QPEL_AVX512ICL 32, 8
+HEVC_PUT_HEVC_QPEL_AVX512ICL 64, 8
 
 %endif
 %endif

--- a/libavcodec/x86/hevc_mc.asm
+++ b/libavcodec/x86/hevc_mc.asm
@@ -89,6 +89,7 @@ QPEL_TABLE 10, 8, w, avx2
 
 QPEL_TABLE  8, 1, b, avx512icl_h
 QPEL_TABLE  8, 1, d, avx512icl_v
+QPEL_TABLE 16, 1, b, avx512icl_h
 
 pb_qpel_shuffle_index: db  0,  1,  2,  3
                        db  1,  2,  3,  4
@@ -98,6 +99,14 @@ pb_qpel_shuffle_index: db  0,  1,  2,  3
                        db  5,  6,  7,  8
                        db  6,  7,  8,  9
                        db  7,  8,  9, 10
+                       db  8,  9, 10, 11
+                       db  9, 10, 11, 12
+                       db 10, 11, 12, 13
+                       db 11, 12, 13, 14
+                       db 12, 13, 14, 15
+                       db 13, 14, 15, 16
+                       db 14, 15, 16, 17
+                       db 15, 16, 17, 18
                        db  4,  5,  6,  7
                        db  5,  6,  7,  8
                        db  6,  7,  8,  9
@@ -106,6 +115,14 @@ pb_qpel_shuffle_index: db  0,  1,  2,  3
                        db  9, 10, 11, 12
                        db 10, 11, 12, 13
                        db 11, 12, 13, 14
+                       db 12, 13, 14, 15
+                       db 13, 14, 15, 16
+                       db 14, 15, 16, 17
+                       db 15, 16, 17, 18
+                       db 16, 17, 18, 19
+                       db 17, 18, 19, 20
+                       db 18, 19, 20, 21
+                       db 19, 20, 21, 22
 
 SECTION .text
 
@@ -1712,7 +1729,7 @@ HEVC_PUT_HEVC_QPEL_HV 16, 10
 
 %macro QPEL_LOAD_SHUF 2
     movu m%1, [pb_qpel_shuffle_index +  0]
-    movu m%2, [pb_qpel_shuffle_index + 32]
+    movu m%2, [pb_qpel_shuffle_index + 64]
 %endmacro
 
 ; required: m0-m5
@@ -1720,7 +1737,11 @@ HEVC_PUT_HEVC_QPEL_HV 16, 10
 ; %2: name for src
 %macro QPEL_H_LOAD_COMPUTE 2
     pxor            m%1, m%1
+%if mmsize == 64
+    movu            ym4, [%2q - 3]
+%else
     movu            xm4, [%2q - 3]
+%endif
     vpermb           m5, m2, m4
     vpermb           m4, m3, m4
     vpdpbusd        m%1, m5, m0
@@ -1804,6 +1825,9 @@ cglobal hevc_put_hevc_qpel_hv%1_%2, 6, 7, 27, dst, src, srcstride, height, mx, m
 INIT_YMM avx512icl
 HEVC_PUT_HEVC_QPEL_AVX512ICL 8, 8
 HEVC_PUT_HEVC_QPEL_HV_AVX512ICL 8, 8
+
+INIT_ZMM avx512icl
+HEVC_PUT_HEVC_QPEL_AVX512ICL 16, 8
 
 %endif
 %endif

--- a/libavcodec/x86/hevcdsp.h
+++ b/libavcodec/x86/hevcdsp.h
@@ -233,6 +233,7 @@ WEIGHTING_PROTOTYPES(8, sse4);
 WEIGHTING_PROTOTYPES(10, sse4);
 WEIGHTING_PROTOTYPES(12, sse4);
 
+void ff_hevc_put_hevc_qpel_h4_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h16_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_hv8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);

--- a/libavcodec/x86/hevcdsp.h
+++ b/libavcodec/x86/hevcdsp.h
@@ -234,6 +234,7 @@ WEIGHTING_PROTOTYPES(10, sse4);
 WEIGHTING_PROTOTYPES(12, sse4);
 
 void ff_hevc_put_hevc_qpel_h8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
+void ff_hevc_put_hevc_qpel_h16_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_hv8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libavcodec/x86/hevcdsp.h
+++ b/libavcodec/x86/hevcdsp.h
@@ -237,6 +237,7 @@ void ff_hevc_put_hevc_qpel_h4_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t
 void ff_hevc_put_hevc_qpel_h8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h16_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h32_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
+void ff_hevc_put_hevc_qpel_h64_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_hv8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libavcodec/x86/hevcdsp.h
+++ b/libavcodec/x86/hevcdsp.h
@@ -236,6 +236,7 @@ WEIGHTING_PROTOTYPES(12, sse4);
 void ff_hevc_put_hevc_qpel_h4_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_h16_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
+void ff_hevc_put_hevc_qpel_h32_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 void ff_hevc_put_hevc_qpel_hv8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libavcodec/x86/hevcdsp.h
+++ b/libavcodec/x86/hevcdsp.h
@@ -233,6 +233,9 @@ WEIGHTING_PROTOTYPES(8, sse4);
 WEIGHTING_PROTOTYPES(10, sse4);
 WEIGHTING_PROTOTYPES(12, sse4);
 
+void ff_hevc_put_hevc_qpel_h8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
+void ff_hevc_put_hevc_qpel_hv8_8_avx512icl(int16_t *dst, uint8_t *_src, ptrdiff_t _srcstride, int height, intptr_t mx, intptr_t my, int width);
+
 ///////////////////////////////////////////////////////////////////////////////
 // TRANSFORM_ADD
 ///////////////////////////////////////////////////////////////////////////////

--- a/libavcodec/x86/hevcdsp_init.c
+++ b/libavcodec/x86/hevcdsp_init.c
@@ -880,6 +880,7 @@ void ff_hevc_dsp_init_x86(HEVCDSPContext *c, const int bit_depth)
         }
         if (EXTERNAL_AVX512ICL(cpu_flags) && ARCH_X86_64) {
             c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_avx512icl;
+            c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_avx512icl;
             c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_avx512icl;
         }
     } else if (bit_depth == 10) {

--- a/libavcodec/x86/hevcdsp_init.c
+++ b/libavcodec/x86/hevcdsp_init.c
@@ -882,6 +882,7 @@ void ff_hevc_dsp_init_x86(HEVCDSPContext *c, const int bit_depth)
             c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_avx512icl;
             c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_avx512icl;
             c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_avx512icl;
+            c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_avx512icl;
             c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_avx512icl;
         }
     } else if (bit_depth == 10) {

--- a/libavcodec/x86/hevcdsp_init.c
+++ b/libavcodec/x86/hevcdsp_init.c
@@ -879,6 +879,7 @@ void ff_hevc_dsp_init_x86(HEVCDSPContext *c, const int bit_depth)
             c->add_residual[3] = ff_hevc_add_residual_32_8_avx2;
         }
         if (EXTERNAL_AVX512ICL(cpu_flags) && ARCH_X86_64) {
+            c->put_hevc_qpel[1][0][1] = ff_hevc_put_hevc_qpel_h4_8_avx512icl;
             c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_avx512icl;
             c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_avx512icl;
             c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_avx512icl;

--- a/libavcodec/x86/hevcdsp_init.c
+++ b/libavcodec/x86/hevcdsp_init.c
@@ -878,6 +878,10 @@ void ff_hevc_dsp_init_x86(HEVCDSPContext *c, const int bit_depth)
 
             c->add_residual[3] = ff_hevc_add_residual_32_8_avx2;
         }
+        if (EXTERNAL_AVX512ICL(cpu_flags) && ARCH_X86_64) {
+            c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_avx512icl;
+            c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_avx512icl;
+        }
     } else if (bit_depth == 10) {
         if (EXTERNAL_MMXEXT(cpu_flags)) {
             c->add_residual[0] = ff_hevc_add_residual_4_10_mmxext;

--- a/libavcodec/x86/hevcdsp_init.c
+++ b/libavcodec/x86/hevcdsp_init.c
@@ -883,6 +883,7 @@ void ff_hevc_dsp_init_x86(HEVCDSPContext *c, const int bit_depth)
             c->put_hevc_qpel[3][0][1] = ff_hevc_put_hevc_qpel_h8_8_avx512icl;
             c->put_hevc_qpel[5][0][1] = ff_hevc_put_hevc_qpel_h16_8_avx512icl;
             c->put_hevc_qpel[7][0][1] = ff_hevc_put_hevc_qpel_h32_8_avx512icl;
+            c->put_hevc_qpel[9][0][1] = ff_hevc_put_hevc_qpel_h64_8_avx512icl;
             c->put_hevc_qpel[3][1][1] = ff_hevc_put_hevc_qpel_hv8_8_avx512icl;
         }
     } else if (bit_depth == 10) {


### PR DESCRIPTION
This commit uses the instruction `vpdpbusd` introduced by AVX512 VNNI
to calculate the horizontal filter.

ff_hevc_put_hevc_qpel_h8_8_sse4       1039169
ff_hevc_put_hevc_qpel_h8_8_avx512icl   677153
ff_hevc_put_hevc_qpel_hv8_8_sse4      3603511
ff_hevc_put_hevc_qpel_hv8_8_avx512icl 2995354

Signed-off-by: Wu Jianhua <jianhua.wu@intel.com>