### PR TITLE
qsvvpp: change the alignment from 32 to 16

### DIFF
--- a/libavfilter/qsvvpp.c
+++ b/libavfilter/qsvvpp.c
@@ -283,8 +283,8 @@ static int fill_frameinfo_by_link(mfxFrameInfo *frameinfo, AVFilterLink *link)
 
         frameinfo->CropX          = 0;
         frameinfo->CropY          = 0;
-        frameinfo->Width          = FFALIGN(link->w, 32);
-        frameinfo->Height         = FFALIGN(link->h, 32);
+        frameinfo->Width          = FFALIGN(link->w, 16);
+        frameinfo->Height         = FFALIGN(link->h, 16);
         frameinfo->PicStruct      = MFX_PICSTRUCT_PROGRESSIVE;
         frameinfo->FourCC         = pix_fmt_to_mfx_fourcc(pix_fmt);
         frameinfo->BitDepthLuma   = desc->comp[0].depth;


### PR DESCRIPTION
During the qsvvpp process, the input width and height are aligned with
16, now change the output alignment from 32 to 16 to align with input.

Signed-off-by: Tong Wu <tong1.wu@intel.com>