### PR TITLE
qsvenc: avoid dereferencing the null pointer

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1726,7 +1726,7 @@ static int encode_frame(AVCodecContext *avctx, QSVEncContext *q,
         goto free;
     }
 
-    if (ret == MFX_WRN_INCOMPATIBLE_VIDEO_PARAM && frame->interlaced_frame)
+    if (ret == MFX_WRN_INCOMPATIBLE_VIDEO_PARAM && frame && frame->interlaced_frame)
         print_interlace_msg(avctx, q);
 
     ret = 0;


### PR DESCRIPTION
The variable AVFrame *frame could be a null pointer, now add a null
pointer check to avoid dereferencing the null pointer.

Signed-off-by: Tong Wu <tong1.wu@intel.com>