### PR TITLE
qsv: add return value check for MFXQueryIMPL

### DIFF
--- a/libavcodec/qsv.c
+++ b/libavcodec/qsv.c
@@ -408,7 +408,10 @@ int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
         return ret;
     }
 
-    MFXQueryIMPL(qs->session, &impl);
+    ret = MFXQueryIMPL(qs->session, &impl);
+    if (ret != MFX_ERR_NONE)
+        return ff_qsv_print_error(avctx, ret,
+                                  "Error querying the session attributes");
 
     switch (MFX_IMPL_BASETYPE(impl)) {
     case MFX_IMPL_SOFTWARE:


### PR DESCRIPTION
add a return value check for function MFXQueryIMPL to handle the error
message.

Signed-off-by: Tong Wu <tong1.wu@intel.com>