### PR TITLE
avutil/hwcontext_qsv: fix D3D11VA hwmap errors

### DIFF
--- a/libavutil/hwcontext_d3d11va.c
+++ b/libavutil/hwcontext_d3d11va.c
@@ -254,6 +254,11 @@ static int d3d11va_frames_init(AVHWFramesContext *ctx)
         return AVERROR(EINVAL);
     }
 
+    if (!hwctx->BindFlags) {
+        av_log(ctx, AV_LOG_DEBUG, "Add render target bindflag for texture\n");
+        hwctx->BindFlags = D3D11_BIND_RENDER_TARGET;
+    }
+
     texDesc = (D3D11_TEXTURE2D_DESC){
         .Width      = ctx->width,
         .Height     = ctx->height,

--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -1376,10 +1376,13 @@ static int qsv_map_to(AVHWFramesContext *dst_ctx,
         case AV_PIX_FMT_D3D11:
         {
             mfxHDLPair *pair = (mfxHDLPair*)hwctx->surfaces[i].Data.MemId;
-            if (pair->first == src->data[0]
-                && pair->second == src->data[1]) {
-                index = i;
-                break;
+            if (pair->first == src->data[0]) {
+                if (hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET
+                    && pair->second == src->data[1]
+                    || hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET) {
+                    index = i;
+                    break;
+                }
             }
         }
 #endif

--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -913,9 +913,16 @@ static int qsv_map_from(AVHWFramesContext *ctx,
         dst->height  = src->height;
 
        if (child_frames_ctx->device_ctx->type == AV_HWDEVICE_TYPE_D3D11VA) {
+#if CONFIG_D3D11VA
+            AVD3D11VAFramesContext* child_frames_hwctx = child_frames_ctx->hwctx;
             mfxHDLPair *pair = (mfxHDLPair*)surf->Data.MemId;
             dst->data[0] = pair->first;
-            dst->data[1] = pair->second;
+            if (child_frames_hwctx->BindFlags & D3D11_BIND_RENDER_TARGET) {
+                dst->data[1] = 0;
+            } else {
+                dst->data[1] = pair->second;
+            }
+#endif
         } else {
             dst->data[3] = child_data;
         }
@@ -943,9 +950,16 @@ static int qsv_map_from(AVHWFramesContext *ctx,
     dummy->height        = src->height;
 
     if (child_frames_ctx->device_ctx->type == AV_HWDEVICE_TYPE_D3D11VA) {
+#if CONFIG_D3D11VA
+        AVD3D11VAFramesContext* child_frames_hwctx = child_frames_ctx->hwctx;
         mfxHDLPair *pair = (mfxHDLPair*)surf->Data.MemId;
         dummy->data[0] = pair->first;
-        dummy->data[1] = pair->second;
+        if (child_frames_hwctx->BindFlags & D3D11_BIND_RENDER_TARGET) {
+            dummy->data[1] = 0;
+        } else {
+            dummy->data[1] = pair->second;
+        }
+#endif
     } else {
         dummy->data[3] = child_data;
     }

--- a/libavutil/hwcontext_qsv.c
+++ b/libavutil/hwcontext_qsv.c
@@ -808,12 +808,23 @@ static int qsv_frames_derive_from(AVHWFramesContext *dst_ctx,
 #if CONFIG_D3D11VA
     case AV_HWDEVICE_TYPE_D3D11VA:
         {
+            dst_ctx->initial_pool_size = src_ctx->initial_pool_size;
             AVD3D11VAFramesContext *dst_hwctx = dst_ctx->hwctx;
-            mfxHDLPair *pair = (mfxHDLPair*)src_hwctx->surfaces[i].Data.MemId;
-            dst_hwctx->texture = (ID3D11Texture2D*)pair->first;
+            dst_hwctx->texture_infos = av_calloc(src_hwctx->nb_surfaces,
+                                                 sizeof(*dst_hwctx->texture_infos));
             if (src_hwctx->frame_type & MFX_MEMTYPE_SHARED_RESOURCE)
                 dst_hwctx->MiscFlags = D3D11_RESOURCE_MISC_SHARED;
             dst_hwctx->BindFlags = qsv_get_d3d11va_bind_flags(src_hwctx->frame_type);
+            for (i = 0; i < src_hwctx->nb_surfaces; i++) {
+                mfxHDLPair* pair = (mfxHDLPair*)src_hwctx->surfaces[i].Data.MemId;
+                dst_hwctx->texture_infos[i].texture = (ID3D11Texture2D*)pair->first;
+                if (dst_hwctx->BindFlags & D3D11_BIND_RENDER_TARGET) {
+                    dst_hwctx->texture_infos[i].index = 0;
+                }
+                else {
+                    dst_hwctx->texture_infos[i].index = (intptr_t)pair->second;
+                }
+            }
         }
         break;
 #endif


### PR DESCRIPTION
The mfxHDLPair information should be put into texture_infos when
deriving from qsv context. Now fix it to make the qsv->d3d11va zero copy
work properly.