### PR TITLE
Enable LowDelayBRC and MaxFrameSizeI/MaxFrameSizeP for more accurate …

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3264,6 +3264,14 @@ Enable rate distortion optimization.
 @item @var{max_frame_size}
 Maximum encoded frame size in bytes.
 
+@item @var{max_frame_size_i}
+Maximum encoded frame size for I frames in bytes. If this value is set as larger
+than zero, then for I frames the value set by max_frame_size is ignored.
+
+@item @var{max_frame_size_p}
+Maximum encoded frame size for P frames in bytes. If this value is set as larger
+than zero, then for P frames the value set by max_frame_size is ignored.
+
 @item @var{max_slice_size}
 Maximum encoded slice size in bytes.
 
@@ -3279,6 +3287,11 @@ by the QSV encoder, it will be changed to be in the range.
 Setting this flag enables macroblock level bitrate control that generally
 improves subjective visual quality. Enabling this flag may have negative impact
 on performance and objective visual quality metric.
+
+@item @var{low_delay_brc}
+Setting this flag turns on or off LowDelayBRC feautre in qsv plugin, which provides
+more accurate bitrate control to minimize the variance of bitstream size frame
+by frame. Value: -1-default 0-off 1-on
 
 @item @var{adaptive_i}
 This flag controls insertion of I frames by the QSV encoder. Turn ON this flag
@@ -3392,6 +3405,14 @@ Enable rate distortion optimization.
 @item @var{max_frame_size}
 Maximum encoded frame size in bytes.
 
+@item @var{max_frame_size_i}
+Maximum encoded frame size for I frames in bytes. If this value is set as larger
+than zero, then for I frames the value set by max_frame_size is ignored.
+
+@item @var{max_frame_size_p}
+Maximum encoded frame size for P frames in bytes. If this value is set as larger
+than zero, then for P frames the value set by max_frame_size is ignored.
+
 @item @var{max_slice_size}
 Maximum encoded slice size in bytes.
 
@@ -3399,6 +3420,11 @@ Maximum encoded slice size in bytes.
 Setting this flag enables macroblock level bitrate control that generally
 improves subjective visual quality. Enabling this flag may have negative impact
 on performance and objective visual quality metric.
+
+@item @var{low_delay_brc}
+Setting this flag turns on or off LowDelayBRC feautre in qsv plugin, which provides
+more accurate bitrate control to minimize the variance of bitstream size frame
+by frame. Value: -1-default 0-off 1-on
 
 @item @var{p_strategy}
 Enable P-pyramid: 0-default 1-simple 2-pyramid(bf need to be set to 0).

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -374,6 +374,13 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
 #if QSV_VERSION_ATLEAST(1, 16)
     av_log(avctx, AV_LOG_VERBOSE, "IntRefCycleDist: %"PRId16"\n", co3->IntRefCycleDist);
 #endif
+#if QSV_VERSION_ATLEAST(1, 23)
+    av_log(avctx, AV_LOG_VERBOSE, "LowDelayBRC: %s\n", print_threestate(co3->LowDelayBRC));
+#endif
+#if QSV_VERSION_ATLEAST(1, 19)
+    av_log(avctx, AV_LOG_VERBOSE, "MaxFrameSizeI: %d; ", co3->MaxFrameSizeI);
+    av_log(avctx, AV_LOG_VERBOSE, "MaxFrameSizeP: %d\n", co3->MaxFrameSizeP);
+#endif
 }
 
 static void dump_video_vp9_param(AVCodecContext *avctx, QSVEncContext *q,
@@ -988,6 +995,16 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
 #if QSV_VERSION_ATLEAST(1, 16)
             if (q->int_ref_cycle_dist >= 0)
                 q->extco3.IntRefCycleDist = q->int_ref_cycle_dist;
+#endif
+#if QSV_VERSION_ATLEAST(1, 23)
+            if (q->low_delay_brc >= 0)
+                q->extco3.LowDelayBRC = q->low_delay_brc ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+#endif
+#if QSV_VERSION_ATLEAST(1, 19)
+            if (q->max_frame_size_p >= 0)
+                q->extco3.MaxFrameSizeI = q->max_frame_size_i;
+            if (q->max_frame_size_p >= 0)
+                q->extco3.MaxFrameSizeP = q->max_frame_size_p;
 #endif
         }
 

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -91,6 +91,8 @@
 { "veryslow",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_TARGETUSAGE_BEST_QUALITY  }, INT_MIN, INT_MAX, VE, "preset" },                                                \
 { "rdo",            "Enable rate distortion optimization",    OFFSET(qsv.rdo),            AV_OPT_TYPE_INT, { .i64 = -1 }, -1,          1, VE },                         \
 { "max_frame_size", "Maximum encoded frame size in bytes",    OFFSET(qsv.max_frame_size), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, UINT16_MAX, VE },                         \
+{ "max_frame_size_i", "Maximum encoded I frame size in bytes",OFFSET(qsv.max_frame_size_i), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, UINT16_MAX, VE },                       \
+{ "max_frame_size_p", "Maximum encoded P frame size in bytes",OFFSET(qsv.max_frame_size_p), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, UINT16_MAX, VE },                       \
 { "max_slice_size", "Maximum encoded slice size in bytes",    OFFSET(qsv.max_slice_size), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, UINT16_MAX, VE },                         \
 { "bitrate_limit",  "Toggle bitrate limitations",             OFFSET(qsv.bitrate_limit),  AV_OPT_TYPE_INT, { .i64 = -1 }, -1,          1, VE },                         \
 { "mbbrc",          "MB level bitrate control",               OFFSET(qsv.mbbrc),          AV_OPT_TYPE_INT, { .i64 = -1 }, -1,          1, VE },                         \
@@ -102,6 +104,7 @@
 { "forced_idr",     "Forcing I frames as IDR frames",         OFFSET(qsv.forced_idr),     AV_OPT_TYPE_BOOL,{ .i64 = 0  },  0,          1, VE },                         \
 { "low_power", "enable low power mode(experimental: many limitations by mfx version, BRC modes, etc.)", OFFSET(qsv.low_power), AV_OPT_TYPE_BOOL, { .i64 = -1}, -1, 1, VE},\
 { "dblk_idc", "This option disable deblocking. It has value in range 0~2.",   OFFSET(qsv.dblk_idc),   AV_OPT_TYPE_INT,    { .i64 = 0 },   0,  2,  VE},    \
+{ "low_delay_brc",   "Allow to strictly obey avg frame size", OFFSET(qsv.low_delay_brc),  AV_OPT_TYPE_BOOL,{ .i64 = -1 }, -1,          1, VE },                         \
 
 extern const AVCodecHWConfigInternal *const ff_qsv_enc_hw_configs[];
 
@@ -173,6 +176,8 @@ typedef struct QSVEncContext {
     int vcm;
     int rdo;
     int max_frame_size;
+    int max_frame_size_i;
+    int max_frame_size_p;
     int max_slice_size;
     int dblk_idc;
 
@@ -212,6 +217,7 @@ typedef struct QSVEncContext {
     char *load_plugins;
     SetEncodeCtrlCB *set_encode_ctrl_cb;
     int forced_idr;
+    int low_delay_brc;
 } QSVEncContext;
 
 int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);


### PR DESCRIPTION
Enable LowDelay BRC and maxFrameSize setting for I/P frames, which will make the bitrate control more accurate.

Signed-off-by: Dmitry Ermilov <dmitry.ermilov@intel.com>