### PR TITLE
hwcontext_qsv: change qsv download/upload to child download/upload

### DIFF
--- a/libavutil/hwcontext_dxva2.c
+++ b/libavutil/hwcontext_dxva2.c
@@ -316,10 +316,10 @@ static int dxva2_map_frame(AVHWFramesContext *ctx, AVFrame *dst, const AVFrame *
         goto fail;
     }
 
-    for (i = 0; i < nb_planes; i++)
+    for (i = 0; i < 4; i++)
         dst->linesize[i] = LockedRect.Pitch;
 
-    av_image_fill_pointers(dst->data, dst->format, surfaceDesc.Height,
+    av_image_fill_pointers(dst->data, ctx->sw_format, surfaceDesc.Height,
                            (uint8_t*)LockedRect.pBits, dst->linesize);
 
     if (dst->format == AV_PIX_FMT_PAL8)


### PR DESCRIPTION
qsv is using MSDK VPP API to process download/upload, now change it to
using child context download/upload methods.

This change can fix the issue on Windows of cm_copy returning wrong
frames.