### PR TITLE
avutil/hwcontext_d3d11va: fix the uninitialized texture bindflag

### DIFF
--- a/libavutil/hwcontext_d3d11va.c
+++ b/libavutil/hwcontext_d3d11va.c
@@ -254,6 +254,11 @@ static int d3d11va_frames_init(AVHWFramesContext *ctx)
         return AVERROR(EINVAL);
     }
 
+    if (!hwctx->BindFlags) {
+        av_log(ctx, AV_LOG_DEBUG, "Add render target bindflag for texture\n");
+        hwctx->BindFlags = D3D11_BIND_RENDER_TARGET;
+    }
+
     texDesc = (D3D11_TEXTURE2D_DESC){
         .Width      = ctx->width,
         .Height     = ctx->height,


### PR DESCRIPTION
When uploading rawvideos using d3d11va hardware framecontext, the bindflag
is not initialized and will cause creating texture failure. Now fix it,
assign it the value of D3D11_BIND_RENDER_TARGET.

Signed-off-by: Tong Wu <tong1.wu@intel.com>