### PR TITLE
libavcodec/cbs_av1: Add size check before parse obu

### DIFF
--- a/libavcodec/cbs_av1.c
+++ b/libavcodec/cbs_av1.c
@@ -1075,6 +1075,9 @@ static int cbs_av1_write_obu(CodedBitstreamContext *ctx,
         put_bits32(pbc, 0);
     }
 
+    if (8 * unit->data_size > put_bits_left(pbc))
+        return AVERROR(ENOSPC);
+
     td = NULL;
     start_pos = put_bits_count(pbc);
 
@@ -1195,9 +1198,6 @@ static int cbs_av1_write_obu(CodedBitstreamContext *ctx,
     data_pos = put_bits_count(pbc) / 8;
     flush_put_bits(pbc);
     av_assert0(data_pos <= start_pos);
-
-    if (8 * obu->obu_size > put_bits_left(pbc))
-        return AVERROR(ENOSPC);
 
     if (obu->obu_size > 0) {
         memmove(pbc->buf + data_pos,


### PR DESCRIPTION
cbs_av1_write_unit() check pbc size after parsing obu frame, and return
AVERROR(ENOSPC) if pbc is small. pbc will be reallocated and this obu
frame will be parsed again, but this may cause error because
CodedBitstreamAV1Context has already been updated, for example
ref_order_hint is updated and will not match this obu frame. Now size
check is added before parsing obu frame to avoid this error.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>