### PR TITLE
libavcodec/qsvenc: Add min/max QP control options for I/P/B frame

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3282,6 +3282,24 @@ Forcing I frames as IDR frames.
 
 @item @var{low_power}
 For encoders set this flag to ON to reduce power consumption and GPU usage.
+
+@item @var{max_qp_i}
+Maximum video quantizer scale for I frame.
+
+@item @var{min_qp_i}
+Minimum video quantizer scale for I frame.
+
+@item @var{max_qp_p}
+Maximum video quantizer scale for P frame.
+
+@item @var{min_qp_p}
+Minimum video quantizer scale for P frame.
+
+@item @var{max_qp_b}
+Maximum video quantizer scale for B frame.
+
+@item @var{min_qp_b}
+Minimum video quantizer scale for B frame.
 @end table
 
 @subsection H264 options

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -930,8 +930,13 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
                 q->extco2.BRefType = q->b_strategy ? MFX_B_REF_PYRAMID : MFX_B_REF_OFF;
 #endif
 #if QSV_VERSION_ATLEAST(1, 9)
-            if (avctx->qmin >= 0 && avctx->qmax >= 0 && avctx->qmin > avctx->qmax) {
-                av_log(avctx, AV_LOG_ERROR, "qmin and or qmax are set but invalid, please make sure min <= max\n");
+            if ((avctx->qmin >= 0 && avctx->qmax >= 0 && avctx->qmin > avctx->qmax) ||
+                (q->max_qp_i >= 0 && q->min_qp_i >= 0 && q->min_qp_i > q->max_qp_i) ||
+                (q->max_qp_p >= 0 && q->min_qp_p >= 0 && q->min_qp_p > q->max_qp_p) ||
+                (q->max_qp_b >= 0 && q->min_qp_b >= 0 && q->min_qp_b > q->max_qp_b)) {
+                av_log(avctx, AV_LOG_ERROR,
+                       "qmin and or qmax are set but invalid,"
+                       " please make sure min <= max\n");
                 return AVERROR(EINVAL);
             }
             if (avctx->qmin >= 0) {
@@ -942,6 +947,18 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
                 q->extco2.MaxQPI = avctx->qmax > 51 ? 51 : avctx->qmax;
                 q->extco2.MaxQPP = q->extco2.MaxQPB = q->extco2.MaxQPI;
             }
+            if (q->min_qp_i >= 0)
+                q->extco2.MinQPI = q->min_qp_i > 51 ? 51 : q->min_qp_i;
+            if (q->max_qp_i >= 0)
+                q->extco2.MaxQPI = q->max_qp_i > 51 ? 51 : q->max_qp_i;
+            if (q->min_qp_p >= 0)
+                q->extco2.MinQPP = q->min_qp_p > 51 ? 51 : q->min_qp_p;
+            if (q->max_qp_p >= 0)
+                q->extco2.MaxQPP = q->max_qp_p > 51 ? 51 : q->max_qp_p;
+            if (q->min_qp_b >= 0)
+                q->extco2.MinQPB = q->min_qp_b > 51 ? 51 : q->min_qp_b;
+            if (q->max_qp_b >= 0)
+                q->extco2.MaxQPB = q->max_qp_b > 51 ? 51 : q->max_qp_b;
 #endif
             if (q->mbbrc >= 0)
                 q->extco2.MBBRC = q->mbbrc ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -105,6 +105,12 @@
 { "low_power", "enable low power mode(experimental: many limitations by mfx version, BRC modes, etc.)", OFFSET(qsv.low_power), AV_OPT_TYPE_BOOL, { .i64 = -1}, -1, 1, VE},\
 { "dblk_idc", "This option disable deblocking. It has value in range 0~2.",   OFFSET(qsv.dblk_idc),   AV_OPT_TYPE_INT,    { .i64 = 0 },   0,  2,  VE},    \
 { "low_delay_brc",   "Allow to strictly obey avg frame size", OFFSET(qsv.low_delay_brc),  AV_OPT_TYPE_BOOL,{ .i64 = -1 }, -1,          1, VE },                         \
+{ "max_qp_i", "Maximum video quantizer scale for I frame",       OFFSET(qsv.max_qp_i),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
+{ "min_qp_i", "Minimum video quantizer scale for I frame",       OFFSET(qsv.min_qp_i),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
+{ "max_qp_p", "Maximum video quantizer scale for P frame",       OFFSET(qsv.max_qp_p),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
+{ "min_qp_p", "Minimum video quantizer scale for P frame",       OFFSET(qsv.min_qp_p),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
+{ "max_qp_b", "Maximum video quantizer scale for B frame",       OFFSET(qsv.max_qp_b),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
+{ "min_qp_b", "Minimum video quantizer scale for B frame",       OFFSET(qsv.min_qp_b),       AV_OPT_TYPE_INT, { .i64 = -1 },  -1,          51, VE},                         \
 
 extern const AVCodecHWConfigInternal *const ff_qsv_enc_hw_configs[];
 
@@ -218,6 +224,12 @@ typedef struct QSVEncContext {
     SetEncodeCtrlCB *set_encode_ctrl_cb;
     int forced_idr;
     int low_delay_brc;
+    int max_qp_i;
+    int min_qp_i;
+    int max_qp_p;
+    int min_qp_p;
+    int max_qp_b;
+    int min_qp_b;
 } QSVEncContext;
 
 int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);


### PR DESCRIPTION
To do more accurate QP control, add min/max QP control on I/P/B frame
separately to qsv encoder.

Signed-off-by: Yue Heng <yue.heng@intel.com>
Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>