### PR TITLE
libavcodec/qsvenc: Enable fixed QP configure in qsv CQP runtime

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3333,6 +3333,15 @@ Forcing I frames as IDR frames.
 For encoders set this flag to ON to reduce power consumption and GPU usage.
 @end table
 
+@subsection Runtime Options
+Following options can be used durning qsv encoding.
+
+@table @option
+@item @var{qsv_config_qp}
+This option can be set in per-frame metadata. QP parameter can be dynamically
+changed when encode in CQP mode.
+@end table
+
 @subsection H264 options
 These options are used by h264_qsv
 

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -146,6 +146,14 @@ static const struct {
     { MFX_RATECONTROL_QVBR,    "QVBR" },
 };
 
+#define UPDATE_PARAM(a, b)  \
+do {                        \
+    if ((a) != (b)) {       \
+        a = b;              \
+        updated = 1;        \
+    }                       \
+} while(0)                  \
+
 static const char *print_ratecontrol(mfxU16 rc_mode)
 {
     int i;
@@ -1520,6 +1528,53 @@ static void print_interlace_msg(AVCodecContext *avctx, QSVEncContext *q)
     }
 }
 
+static int update_qp(AVCodecContext *avctx, QSVEncContext *q,
+                     const AVFrame *frame)
+{
+    int updated = 0, qp = 0, new_qp;
+    AVDictionaryEntry *entry = av_dict_get(frame->metadata, "qsv_config_qp",
+                                           NULL, 0);
+    if (entry && q->param.mfx.RateControlMethod == MFX_RATECONTROL_CQP) {
+        qp = atoi(entry->value);
+        av_log(avctx, AV_LOG_DEBUG, "Configure qp: %d\n",qp);
+        if (qp < 0 || qp > 51)
+            av_log(avctx, AV_LOG_WARNING, "Invalid qp, clip to 0 ~ 51\n");
+
+        qp = av_clip(qp, 0, 51);
+        UPDATE_PARAM(q->param.mfx.QPP, qp);
+        new_qp = av_clip(qp * fabs(avctx->i_quant_factor) +
+                            avctx->i_quant_offset, 0, 51);
+        UPDATE_PARAM(q->param.mfx.QPI, new_qp);
+        new_qp = av_clip(qp * fabs(avctx->b_quant_factor) +
+                            avctx->b_quant_offset, 0, 51);
+        UPDATE_PARAM(q->param.mfx.QPB, new_qp);
+        av_log(avctx, AV_LOG_DEBUG,
+                "using fixed qp = %d/%d/%d for idr/p/b frames\n",
+                q->param.mfx.QPI, q->param.mfx.QPP, q->param.mfx.QPB);
+    }
+    return updated;
+}
+
+static int update_parameters(AVCodecContext *avctx, QSVEncContext *q,
+                             const AVFrame *frame)
+{
+    int needReset = 0, ret = 0;
+
+    if (!frame)
+        return 0;
+
+    needReset = update_qp(avctx, q, frame);
+    if (needReset) {
+        q->param.ExtParam    = q->extparam_internal;
+        q->param.NumExtParam = q->nb_extparam_internal;
+        av_log(avctx, AV_LOG_DEBUG, "Parameter change, call msdk reset.\n");
+        ret = MFXVideoENCODE_Reset(q->session, &q->param);
+        if (ret < 0)
+            return ff_qsv_print_error(avctx, ret, "Error during resetting");
+    }
+    return 0;
+}
+
 static int encode_frame(AVCodecContext *avctx, QSVEncContext *q,
                         const AVFrame *frame)
 {
@@ -1629,6 +1684,10 @@ int ff_qsv_encode(AVCodecContext *avctx, QSVEncContext *q,
                   AVPacket *pkt, const AVFrame *frame, int *got_packet)
 {
     int ret;
+
+    ret = update_parameters(avctx, q, frame);
+    if (ret < 0)
+        return ret;
 
     ret = encode_frame(avctx, q, frame);
     if (ret < 0)


### PR DESCRIPTION
Enable dynamic QP configuration in runtime on qsv encoder. Through
AVFrame->metadata, we can set key "qsv_config_qp" to change QP
configuration when we encode video in CQP mode.

Signed-off-by: Yue Heng <yue.heng@intel.com>
Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>