### PR TITLE
avutil/hwcontext_d3d11va: add bgra as supported formats

### DIFF
--- a/libavutil/hwcontext_d3d11va.c
+++ b/libavutil/hwcontext_d3d11va.c
@@ -86,6 +86,7 @@ static const struct {
 } supported_formats[] = {
     { DXGI_FORMAT_NV12,         AV_PIX_FMT_NV12 },
     { DXGI_FORMAT_P010,         AV_PIX_FMT_P010 },
+    { DXGI_FORMAT_B8G8R8A8_UNORM, AV_PIX_FMT_BGRA },
     // Special opaque formats. The pix_fmt is merely a place holder, as the
     // opaque format cannot be accessed directly.
     { DXGI_FORMAT_420_OPAQUE,   AV_PIX_FMT_YUV420P },


### PR DESCRIPTION
This enables the command line
ffmpeg.exe -init_hw_devce qsv=qsv:hw_any,child_device_type=d3d11va \
-pix_fmt bgra -s:v 1920x1080 -i input.bgra -vf \
"hwupload=extra_hw_frames=16,vpp_qsv=format=nv12" -f null -

Signed-off-by: Tong Wu <tong1.wu@intel.com>