### PR TITLE
libavcodec/qsvenc: Add support to qsv to encode external surface.

### DIFF
--- a/libavcodec/qsv_internal.h
+++ b/libavcodec/qsv_internal.h
@@ -90,6 +90,7 @@ typedef struct QSVFrame {
 
     int queued;
     int used;
+    int external_frame;
 
     struct QSVFrame *next;
 } QSVFrame;

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1413,6 +1413,10 @@ static void clear_unused_frames(QSVEncContext *q)
             memset(&cur->enc_ctrl, 0, sizeof(cur->enc_ctrl));
             cur->enc_ctrl.Payload = cur->payloads;
             cur->enc_ctrl.ExtParam = cur->extparam;
+            if (cur->external_frame) {
+                av_freep(&cur->surface.Data.MemId);
+                cur->external_frame = 0;
+            }
             if (cur->frame->format == AV_PIX_FMT_QSV) {
                 av_frame_unref(cur->frame);
             }
@@ -1478,10 +1482,17 @@ static int submit_frame(QSVEncContext *q, const AVFrame *frame,
 
         if (q->frames_ctx.mids) {
             ret = ff_qsv_find_surface_idx(&q->frames_ctx, qf);
-            if (ret < 0)
-                return ret;
-
-            qf->surface.Data.MemId = &q->frames_ctx.mids[ret];
+            if (ret >= 0)
+                qf->surface.Data.MemId = &q->frames_ctx.mids[ret];
+        }
+        if (!q->frames_ctx.mids || ret < 0) {
+            QSVMid *mid = NULL;
+            mid = (QSVMid *)av_mallocz(sizeof(*mid));
+            if (!mid)
+                return AVERROR(ENOMEM);
+            mid->handle_pair = (mfxHDLPair *)qf->surface.Data.MemId;
+            qf->surface.Data.MemId = mid;
+            qf->external_frame = 1;
         }
     } else {
         /* make a copy if the input is not padded as libmfx requires */


### PR DESCRIPTION
Qsv encoder only encode the frame that are pre-allocated, so qsv encoder
cannot encode the frame mapped from other components. In fact, MediaSDK
can encode frame that are dynamically created. I add the support to qsv
to encode external frame. Now the following command line works:

ffmpeg -v verbose -init_hw_device vaapi=va -init_hw_device qsv=qs@va \
-hwaccel qsv -hwaccel_device qs -c:v h264_qsv -i input.264 -vf       \
"hwmap=derive_device=vaapi,format=vaapi,                             \
hwmap=derive_device=qsv:reverse=1:extra_hw_frames=16,format=qsv"     \
-c:v h264_qsv output.264

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
Signed-off-by: Tong Wu <tong1.wu@intel.com>