### PR TITLE
avfilter/avfiltergraph: add an auto hwmap filter

### DIFF
--- a/libavfilter/formats.c
+++ b/libavfilter/formats.c
@@ -326,18 +326,36 @@ static const AVFilterFormatsMerger mergers_audio[] = {
     },
 };
 
+static const AVFilterFormatsFilter filters_video[] = {
+    {
+        .conversion_filter = "scale",
+        .conversion_opts_offset = offsetof(AVFilterGraph, scale_sws_opts),
+    },
+    {
+        .conversion_filter = "hwmap",
+        .conversion_opts_offset = 0,
+    }
+};
+
+static const AVFilterFormatsFilter filters_audio[] = {
+    {
+        .conversion_filter = "aresample",
+        .conversion_opts_offset = offsetof(AVFilterGraph, aresample_swr_opts),
+    }
+};
+
 static const AVFilterNegotiation negotiate_video = {
     .nb_mergers = FF_ARRAY_ELEMS(mergers_video),
     .mergers = mergers_video,
-    .conversion_filter = "scale",
-    .conversion_opts_offset = offsetof(AVFilterGraph, scale_sws_opts),
+    .nb_conversion_filters = FF_ARRAY_ELEMS(filters_video),
+    .conversion_filters = filters_video,
 };
 
 static const AVFilterNegotiation negotiate_audio = {
     .nb_mergers = FF_ARRAY_ELEMS(mergers_audio),
     .mergers = mergers_audio,
-    .conversion_filter = "aresample",
-    .conversion_opts_offset = offsetof(AVFilterGraph, aresample_swr_opts),
+    .nb_conversion_filters = FF_ARRAY_ELEMS(filters_audio),
+    .conversion_filters = filters_audio,
 };
 
 const AVFilterNegotiation *ff_filter_get_negotiation(AVFilterLink *link)

--- a/libavfilter/formats.h
+++ b/libavfilter/formats.h
@@ -330,6 +330,11 @@ typedef struct AVFilterFormatMerger {
     int (*can_merge)(const void *a, const void *b);
 } AVFilterFormatsMerger;
 
+typedef struct AVFilterFormatFilter {
+    const char *conversion_filter;
+    unsigned conversion_opts_offset;
+} AVFilterFormatsFilter;
+
 /**
  * Callbacks and properties to describe the steps of a format negotiation.
  *
@@ -418,8 +423,8 @@ typedef struct AVFilterFormatMerger {
 typedef struct AVFilterNegotiation {
     unsigned nb_mergers;
     const AVFilterFormatsMerger *mergers;
-    const char *conversion_filter;
-    unsigned conversion_opts_offset;
+    unsigned nb_conversion_filters;
+    const AVFilterFormatsFilter *conversion_filters;
 } AVFilterNegotiation;
 
 const AVFilterNegotiation *ff_filter_get_negotiation(AVFilterLink *link);

--- a/libavutil/hwcontext.c
+++ b/libavutil/hwcontext.c
@@ -80,6 +80,18 @@ static const char *const hw_type_names[] = {
     [AV_HWDEVICE_TYPE_VULKAN] = "vulkan",
 };
 
+enum AVHWDeviceType av_hwdevice_get_type_by_pix_fmt(enum AVPixelFormat fmt)
+{
+    int i, j;
+    for (i = 0; hw_table[i]; i++) {
+        for (j = 0; hw_table[i]->pix_fmts[j] != AV_PIX_FMT_NONE; j++) {
+            if (hw_table[i]->pix_fmts[j] == fmt)
+                return hw_table[i]->type;
+        }
+    }
+    return AV_HWDEVICE_TYPE_NONE;
+}
+
 enum AVHWDeviceType av_hwdevice_find_type_by_name(const char *name)
 {
     int type;

--- a/libavutil/hwcontext.h
+++ b/libavutil/hwcontext.h
@@ -230,6 +230,15 @@ typedef struct AVHWFramesContext {
 } AVHWFramesContext;
 
 /**
+ * Get the device type by a given pixel format.
+ *
+ * @param fmt Pixel format from enum AVPixelFormat.
+ * @return The type from enum AVHWDeviceType, or AV_HWDEVICE_TYPE_NONE if
+ *         not found.
+ */
+enum AVHWDeviceType av_hwdevice_get_type_by_pix_fmt(enum AVPixelFormat fmt);
+
+/**
  * Look up an AVHWDeviceType by name.
  *
  * @param name String name of the device type (case-insensitive).


### PR DESCRIPTION
When two formats lists cannot be merged, a scale filter is
auto-inserted. However, when it comes to hardware map, we have to
manually add a hwmap filter to do the conversion. This patch introduces
an auto hwmap filter to do the hwmap conversion automatically. It is
added to the AVFilterGraph only after both the original merge and the
auto-scale merge fail.