### PR TITLE
lavf/sr: fix the segmentation fault, caused by incorrect input frame in

### DIFF
--- a/libavfilter/vf_sr.c
+++ b/libavfilter/vf_sr.c
@@ -159,8 +159,9 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
         sws_scale(ctx->sws_uv_scale, (const uint8_t **)(in->data + 2), in->linesize + 2,
                   0, ctx->sws_uv_height, out->data + 2, out->linesize + 2);
     }
-
-    av_frame_free(&in);
+    if (in != out) {
+        av_frame_free(&in);
+    }
     return ff_filter_frame(outlink, out);
 }
 


### PR DESCRIPTION
backend.

This issue would cause segmetaion fault when running srcnn model with
TensorFlow backend. It was introduced by incorrect input frame pointer.