### PR TITLE
[test]libavcodec/qsvenc: Use parameter from AVCodecContext to reset qsv codec

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3337,10 +3337,13 @@ For encoders set this flag to ON to reduce power consumption and GPU usage.
 Following options can be used durning qsv encoding.
 
 @table @option
-@item @var{qsv_config_qp}
+@item @var{global_quality}
+@item @var{i_quant_factor}
+@item @var{i_quant_offset}
+@item @var{b_quant_factor}
+@item @var{b_quant_offset}
 Supported in h264_qsv and hevc_qsv.
-This option can be set in per-frame metadata. QP parameter can be dynamically
-changed when encoding in CQP mode.
+Change these value to reset qsv codec's qp configuration.
 @end table
 
 @subsection H264 options

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -738,6 +738,11 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
         q->param.mfx.QPI = av_clip(quant * fabs(avctx->i_quant_factor) + avctx->i_quant_offset, 0, 51);
         q->param.mfx.QPP = av_clip(quant, 0, 51);
         q->param.mfx.QPB = av_clip(quant * fabs(avctx->b_quant_factor) + avctx->b_quant_offset, 0, 51);
+        q->old_global_quality = avctx->global_quality;
+        q->old_i_quant_factor = avctx->i_quant_factor;
+        q->old_i_quant_offset = avctx->i_quant_offset;
+        q->old_b_quant_factor = avctx->b_quant_factor;
+        q->old_b_quant_offset = avctx->b_quant_offset;
 
         break;
 #if QSV_HAVE_AVBR
@@ -1621,38 +1626,31 @@ static int set_roi_encode_ctrl(AVCodecContext *avctx, const AVFrame *frame,
     return 0;
 }
 
-static int update_qp(AVCodecContext *avctx, QSVEncContext *q,
-                     const AVFrame *frame)
+static int update_qp(AVCodecContext *avctx, QSVEncContext *q)
 {
-    int updated = 0, qp = 0, new_qp;
-    char *tail;
-    AVDictionaryEntry *entry = NULL;
+    int updated = 0, new_qp = 0;
 
     if (avctx->codec_id != AV_CODEC_ID_H264 && avctx->codec_id != AV_CODEC_ID_HEVC)
         return 0;
 
-    entry = av_dict_get(frame->metadata, "qsv_config_qp", NULL, 0);
-    if (entry && q->param.mfx.RateControlMethod == MFX_RATECONTROL_CQP) {
-        qp = strtol(entry->value, &tail, 10);
-        if (*tail) {
-            av_log(avctx, AV_LOG_WARNING, "Invalid qsv_config_qp string. Ignore this metadata\n");
+    if (q->param.mfx.RateControlMethod == MFX_RATECONTROL_CQP) {
+        UPDATE_PARAM(q->old_global_quality, avctx->global_quality);
+        UPDATE_PARAM(q->old_i_quant_factor, avctx->i_quant_factor);
+        UPDATE_PARAM(q->old_i_quant_offset, avctx->i_quant_offset);
+        UPDATE_PARAM(q->old_b_quant_factor, avctx->b_quant_factor);
+        UPDATE_PARAM(q->old_b_quant_offset, avctx->b_quant_offset);
+        if (!updated)
             return 0;
-        }
-        if (qp < 0 || qp > 51) {
-            av_log(avctx, AV_LOG_WARNING, "Invalid qp, clip to 0 ~ 51\n");
-            qp = av_clip(qp, 0, 51);
-        }
-        av_log(avctx, AV_LOG_DEBUG, "Configure qp: %d\n",qp);
-        UPDATE_PARAM(q->param.mfx.QPP, qp);
-        new_qp = av_clip(qp * fabs(avctx->i_quant_factor) +
-                            avctx->i_quant_offset, 0, 51);
-        UPDATE_PARAM(q->param.mfx.QPI, new_qp);
-        new_qp = av_clip(qp * fabs(avctx->b_quant_factor) +
-                            avctx->b_quant_offset, 0, 51);
-        UPDATE_PARAM(q->param.mfx.QPB, new_qp);
+
+        new_qp = avctx->global_quality / FF_QP2LAMBDA;
+        q->param.mfx.QPI = av_clip(new_qp * fabs(avctx->i_quant_factor) +
+                                    avctx->i_quant_offset, 0, 51);
+        q->param.mfx.QPP = av_clip(new_qp, 0, 51);
+        q->param.mfx.QPB = av_clip(new_qp * fabs(avctx->b_quant_factor) +
+                                    avctx->b_quant_offset, 0, 51);
         av_log(avctx, AV_LOG_DEBUG,
-                "using fixed qp = %d/%d/%d for idr/p/b frames\n",
-                q->param.mfx.QPI, q->param.mfx.QPP, q->param.mfx.QPB);
+               "Reset qp = %d/%d/%d for idr/p/b frames\n",
+               q->param.mfx.QPI, q->param.mfx.QPP, q->param.mfx.QPB);
     }
     return updated;
 }
@@ -1665,7 +1663,7 @@ static int update_parameters(AVCodecContext *avctx, QSVEncContext *q,
     if (!frame)
         return 0;
 
-    needReset = update_qp(avctx, q, frame);
+    needReset = update_qp(avctx, q);
     if (!needReset)
         return 0;
 

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -224,6 +224,12 @@ typedef struct QSVEncContext {
     int min_qp_p;
     int max_qp_b;
     int min_qp_b;
+    // These are used for qp reset
+    int old_global_quality;
+    float old_i_quant_factor;
+    float old_i_quant_offset;
+    float old_b_quant_factor;
+    float old_b_quant_offset;
 } QSVEncContext;
 
 int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);


### PR DESCRIPTION
Using parameter from AVCodecContext to reset qsv codec is more suitable
for MFXVideoENCODE_Reset()'s usage. Per-frame metadata is more suitable
for the usage of mfxEncodeCtrl being passed to
MFXVideoENCODE_EncodeFrameAsync(). Now change it to use the value
from AVCodecContext.

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>