### PR TITLE
libavcodec/qsvenc_hevc: add tier option

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3654,6 +3654,15 @@ Set the encoding profile (scc requires libmfx >= 1.32).
 @item scc
 @end table
 
+@item @var{tier}
+Set the encoding tier (only level >= 4 can support high tier).
+This option only takes effect when the level option is specified.
+
+@table @samp
+@item main
+@item high
+@end table
+
 @item @var{gpb}
 1: GPB (generalized P/B frame)
 

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -614,8 +614,11 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
         return AVERROR_BUG;
     q->param.mfx.CodecId = ret;
 
-    if (avctx->level > 0)
+    if (avctx->level > 0) {
         q->param.mfx.CodecLevel = avctx->level;
+        if (avctx->codec_id == AV_CODEC_ID_HEVC && avctx->level >= MFX_LEVEL_HEVC_4)
+            q->param.mfx.CodecLevel |= q->tier;
+    }
 
     if (avctx->compression_level == FF_COMPRESSION_DEFAULT) {
         avctx->compression_level = q->preset;

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -180,6 +180,7 @@ typedef struct QSVEncContext {
     int async_depth;
     int idr_interval;
     int profile;
+    int tier;
     int preset;
     int avbr_accuracy;
     int avbr_convergence;

--- a/libavcodec/qsvenc_hevc.c
+++ b/libavcodec/qsvenc_hevc.c
@@ -258,6 +258,9 @@ static const AVOption options[] = {
 #if QSV_VERSION_ATLEAST(1, 32)
     { "scc",     NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_HEVC_SCC     }, INT_MIN, INT_MAX,     VE, "profile" },
 #endif
+    { "tier",    "Set the encoding tier (only level >= 4 can support high tier)", OFFSET(qsv.tier), AV_OPT_TYPE_INT, { .i64 = MFX_TIER_HEVC_HIGH }, MFX_TIER_HEVC_MAIN, MFX_TIER_HEVC_HIGH, VE, "tier" },
+    { "main",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_TIER_HEVC_MAIN       }, INT_MIN, INT_MAX,     VE, "tier" },
+    { "high",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_TIER_HEVC_HIGH       }, INT_MIN, INT_MAX,     VE, "tier" },
 
     { "gpb", "1: GPB (generalized P/B frame); 0: regular P frame", OFFSET(qsv.gpb), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE},
 


### PR DESCRIPTION
Without this change, MSDK always defaults the HEVC tier to MAIN if the `-level` is specified.

In addition, I set the default value of tier option to HIGH if the level >= 4.0 is specified, which has better tolerance for bitrate. This is because I observed a situation where the user does not know the max bitrate that the default MAIN tier can carry when setting the bitrate and level, which usually results in blocky videos due to the exceeded bitrate. For example, HEVC Main Level 5.0, Main Tier can only carry 25M while High Tier can carry 100M as per the HEVC specs.

I'd like to know your opinion on this.