### PR TITLE
lavc/qsvenc_h264: don't support P010 format

### DIFF
--- a/libavcodec/qsvenc_h264.c
+++ b/libavcodec/qsvenc_h264.c
@@ -197,7 +197,6 @@ const FFCodec ff_h264_qsv_encoder = {
     .close          = qsv_enc_close,
     .p.capabilities = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_HYBRID,
     .p.pix_fmts     = (const enum AVPixelFormat[]){ AV_PIX_FMT_NV12,
-                                                    AV_PIX_FMT_P010,
                                                     AV_PIX_FMT_QSV,
                                                     AV_PIX_FMT_NONE },
     .p.priv_class   = &class,


### PR DESCRIPTION
Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>