### PR TITLE
libavfilter/qsvvpp: Use different alignment for YUV420P format

### DIFF
--- a/libavfilter/qsvvpp.c
+++ b/libavfilter/qsvvpp.c
@@ -1003,3 +1003,16 @@ int ff_qsvvpp_create_mfx_session(void *ctx,
 }
 
 #endif
+
+AVFrame *ff_qsvvpp_get_video_buffer(AVFilterLink *inlink, int w, int h)
+{
+    /* When process YUV420 frames, FFmpeg uses same alignment on Y/U/V
+     * planes. VPL and MSDK use Y plane's pitch / 2 as U/V planes's
+     * pitch, which makes U/V planes 16-bytes aligned. We need to set a
+     * separate alignment to meet runtime's behaviour.
+    */
+    return ff_default_get_video_buffer2(inlink,
+                                        FFALIGN(inlink->w, 32),
+                                        FFALIGN(inlink->h, 32),
+                                        16);
+}

--- a/libavfilter/qsvvpp.h
+++ b/libavfilter/qsvvpp.h
@@ -127,4 +127,5 @@ int ff_qsvvpp_print_warning(void *log_ctx, mfxStatus err,
 int ff_qsvvpp_create_mfx_session(void *ctx, void *loader, mfxIMPL implementation,
                                  mfxVersion *pver, mfxSession *psession);
 
+AVFrame *ff_qsvvpp_get_video_buffer(AVFilterLink *inlink, int w, int h);
 #endif /* AVFILTER_QSVVPP_H */

--- a/libavfilter/vf_deinterlace_qsv.c
+++ b/libavfilter/vf_deinterlace_qsv.c
@@ -581,6 +581,7 @@ static const AVFilterPad qsvdeint_inputs[] = {
         .name         = "default",
         .type         = AVMEDIA_TYPE_VIDEO,
         .filter_frame = qsvdeint_filter_frame,
+        .get_buffer.video = ff_qsvvpp_get_video_buffer,
     },
 };
 

--- a/libavfilter/vf_overlay_qsv.c
+++ b/libavfilter/vf_overlay_qsv.c
@@ -399,11 +399,13 @@ static const AVFilterPad overlay_qsv_inputs[] = {
         .name          = "main",
         .type          = AVMEDIA_TYPE_VIDEO,
         .config_props  = config_main_input,
+        .get_buffer.video = ff_qsvvpp_get_video_buffer,
     },
     {
         .name          = "overlay",
         .type          = AVMEDIA_TYPE_VIDEO,
         .config_props  = config_overlay_input,
+        .get_buffer.video = ff_qsvvpp_get_video_buffer,
     },
 };
 

--- a/libavfilter/vf_scale_qsv.c
+++ b/libavfilter/vf_scale_qsv.c
@@ -641,6 +641,7 @@ static const AVFilterPad qsvscale_inputs[] = {
         .name         = "default",
         .type         = AVMEDIA_TYPE_VIDEO,
         .filter_frame = qsvscale_filter_frame,
+        .get_buffer.video = ff_qsvvpp_get_video_buffer,
     },
 };
 

--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -634,6 +634,7 @@ static const AVFilterPad vpp_inputs[] = {
         .name          = "default",
         .type          = AVMEDIA_TYPE_VIDEO,
         .config_props  = config_input,
+        .get_buffer.video = ff_qsvvpp_get_video_buffer,
     },
 };
 


### PR DESCRIPTION
When process yuv420 frames, FFmpeg use same alignment on Y/U/V planes. VPL and MSDK use Y plane's pitch / 2 as U/V planes's pitch, which make U/V planes 16-bytes aligned. We need to set a separate alignment to meet runtime's behaviour.

Now the commandline works fine:
ffmpeg -f rawvideo -pix_fmt yuv420p -s:v 3082x1884 \ -i ./3082x1884.yuv -vf 'vpp_qsv=w=2466:h=1508' -f rawvideo \ -pix_fmt yuv420p 2466_1508.yuv

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>