### PR TITLE
libavcodec/qsvenc: Enable 444 encoding for RGB input

### DIFF
--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -1088,6 +1088,10 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
                 q->extco3.MaxFrameSizeI = q->max_frame_size_i;
             if (q->max_frame_size_p >= 0)
                 q->extco3.MaxFrameSizeP = q->max_frame_size_p;
+            if (sw_format == AV_PIX_FMT_BGRA &&
+                (q->profile == MFX_PROFILE_HEVC_REXT ||
+                q->profile == MFX_PROFILE_UNKNOWN))
+                q->extco3.TargetChromaFormatPlus1 = MFX_CHROMAFORMAT_YUV444 + 1;
 
             q->extco3.ScenarioInfo = q->scenario;
         }


### PR DESCRIPTION
MSDK/VPL uses 420 chroma format as default to encode RGB. This is for the purose of backward compatibility. Now enable 444 encoding output. https://github.com/Intel-Media-SDK/MediaSDK/blob/master/doc/mediasdk-man.md#mfxextcodingoption3 see the description of "TargetChromaFormatPlus1"

Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>