### PR TITLE
qsvenc: add the support of lookahead for CBR and VBR on Windows

### DIFF
--- a/doc/encoders.texi
+++ b/doc/encoders.texi
@@ -3672,7 +3672,7 @@ A :-separate list of hexadecimal plugin UIDs to load in
 an internal session.
 
 @item @var{look_ahead_depth}
-Depth of look ahead in number frames, available when extbrc option is enabled.
+Depth of look ahead in number frames, available when extbrc option is enabled for Linux or scenario is set to 7 for Windows.
 
 @item @var{profile}
 Set the encoding profile (scc requires libmfx >= 1.32).
@@ -3863,7 +3863,7 @@ This option controls usage of B frames as reference.
 Extended bitrate control.
 
 @item @var{look_ahead_depth}
-Depth of look ahead in number frames, available when extbrc option is enabled.
+Depth of look ahead in number frames, available when extbrc option is enabled for Linux or scenario is set to 7 for Windows.
 
 @item @var{low_delay_brc}
 Setting this flag turns on or off LowDelayBRC feautre in qsv plugin, which provides

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -285,7 +285,8 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
            info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
 
     if (co2) {
-        if ((info->RateControlMethod == MFX_RATECONTROL_VBR && q->extbrc && q->look_ahead_depth > 0) ||
+        if ((((info->RateControlMethod == MFX_RATECONTROL_VBR) ||
+            (info->RateControlMethod == MFX_RATECONTROL_CBR)) && q->look_ahead_depth > 0) ||
             (info->RateControlMethod == MFX_RATECONTROL_LA) ||
             (info->RateControlMethod == MFX_RATECONTROL_LA_HRD) ||
             (info->RateControlMethod == MFX_RATECONTROL_LA_ICQ))
@@ -874,7 +875,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
     switch (q->param.mfx.RateControlMethod) {
     case MFX_RATECONTROL_CBR:
     case MFX_RATECONTROL_VBR:
-        if (q->extbrc) {
+        if (q->look_ahead_depth > 0) {
             q->extco2.LookAheadDepth = q->look_ahead_depth;
         }
 #if QSV_HAVE_VCM
@@ -1129,6 +1130,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
             if (q->low_delay_brc >= 0)
                 q->extco3.LowDelayBRC = q->low_delay_brc ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
             q->old_low_delay_brc = q->low_delay_brc;
+            q->extco3.ScenarioInfo = q->scenario;
         }
 
         if (avctx->codec_id == AV_CODEC_ID_HEVC) {

--- a/libavcodec/qsvenc_av1.c
+++ b/libavcodec/qsvenc_av1.c
@@ -106,6 +106,7 @@ static av_cold int qsv_enc_close(AVCodecContext *avctx)
 #define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
 static const AVOption options[] = {
     QSV_COMMON_OPTS
+    QSV_OPTION_SCENARIO
     QSV_OPTION_B_STRATEGY
     QSV_OPTION_ADAPTIVE_I
     QSV_OPTION_ADAPTIVE_B
@@ -117,7 +118,7 @@ static const AVOption options[] = {
         { "main"    , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_AV1_MAIN     }, INT_MIN, INT_MAX,     VE, "profile" },
     { "tile_cols",  "Number of columns for tiled encoding",   OFFSET(qsv.tile_cols),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, UINT16_MAX, VE },
     { "tile_rows",  "Number of rows for tiled encoding",      OFFSET(qsv.tile_rows),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, UINT16_MAX, VE },
-    { "look_ahead_depth", "Depth of look ahead in number frames, available when extbrc option is enabled", OFFSET(qsv.look_ahead_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 100, VE },
+    { "look_ahead_depth", "Depth of look ahead in number frames", OFFSET(qsv.look_ahead_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 100, VE },
     { NULL },
 };
 

--- a/libavcodec/qsvenc_hevc.c
+++ b/libavcodec/qsvenc_hevc.c
@@ -332,7 +332,7 @@ static const AVOption options[] = {
     { "load_plugins", "A :-separate list of hexadecimal plugin UIDs to load in an internal session",
         OFFSET(qsv.load_plugins), AV_OPT_TYPE_STRING, { .str = "" }, 0, 0, VE },
 
-    { "look_ahead_depth", "Depth of look ahead in number frames, available when extbrc option is enabled", OFFSET(qsv.look_ahead_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 100, VE },
+    { "look_ahead_depth", "Depth of look ahead in number frames", OFFSET(qsv.look_ahead_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 100, VE },
     { "profile", NULL, OFFSET(qsv.profile), AV_OPT_TYPE_INT, { .i64 = MFX_PROFILE_UNKNOWN }, 0, INT_MAX, VE, "profile" },
     { "unknown", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_UNKNOWN      }, INT_MIN, INT_MAX,     VE, "profile" },
     { "main",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_HEVC_MAIN    }, INT_MIN, INT_MAX,     VE, "profile" },


### PR DESCRIPTION
add the support of lookahead for CBR and VBR on Windows