### PR TITLE
lavfi/vf_vpp_qsv: set the right timestamp for AVERROR_EOF

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -602,6 +602,7 @@ not_ready:
     return FFERROR_NOT_READY;
 
 eof:
+    pts = av_rescale_q(pts, inlink->time_base, outlink->time_base);
     ff_outlink_set_status(outlink, status, pts);
     return 0;
 }


### PR DESCRIPTION
This can fix tickets 10261 and 10262