### PR TITLE
lavfi: add hwdevice flag to hwupload/hwmap

### DIFF
--- a/libavfilter/vf_hwmap.c
+++ b/libavfilter/vf_hwmap.c
@@ -427,4 +427,5 @@ const AVFilter ff_vf_hwmap = {
     FILTER_OUTPUTS(hwmap_outputs),
     FILTER_QUERY_FUNC(hwmap_query_formats),
     .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
+    .flags          = AVFILTER_FLAG_HWDEVICE,
 };

--- a/libavfilter/vf_hwupload.c
+++ b/libavfilter/vf_hwupload.c
@@ -258,4 +258,5 @@ const AVFilter ff_vf_hwupload = {
     FILTER_OUTPUTS(hwupload_outputs),
     FILTER_QUERY_FUNC(hwupload_query_formats),
     .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
+    .flags          = AVFILTER_FLAG_HWDEVICE,
 };


### PR DESCRIPTION
This fixes a regression introduced by:

  commit 3f63685c3554aea7f72bab1fdbde440820816d37
   and
  commit 632c34993195f716e9fa575af3de80d07fd50991

...where command-lines like:

ffmpeg -v verbose -hwaccel qsv \
  -init_hw_device qsv=qsv,child_device=/dev/dri/renderD128 \
  -hwaccel_output_format qsv -f rawvideo -pix_fmt yuv420p \
  -s:v 352x288 -r:v 25 -i input.yuv \
  -vf 'format=nv12,hwupload=extra_hw_frames=120' \
  -an -c:v h264_qsv -y output.h264

ffmpeg -v verbose -hwaccel qsv \
  -init_hw_device qsv=qsv,child_device=/dev/dri/renderD128 \
  -hwaccel_output_format qsv -f rawvideo -pix_fmt nv12 \
  -s:v 352x288 -r:v 25 -i input.yuv \
  -vf 'format=nv12|qsv,hwupload=extra_hw_frames=16,vpp_qsv=procamp=1:saturation=1.0,hwdownload,format=nv12' \
  -pix_fmt nv12 -f rawvideo -fps_mode passthrough -an -y output.yuv

...produced errors like:

[hwupload @ 0x55b6171d0dc0] A hardware device reference is required to upload frames to. [Parsed_hwupload_1 @ 0x55b6172053c0] Query format failed for 'Parsed_hwupload_1': Invalid argument Error reinitializing filters!
Failed to inject frame into filter network: Invalid argument