### PR TITLE
lavfi/overlay_vaapi: check whether premultiplied alpha is supported

### DIFF
--- a/doc/filters.texi
+++ b/doc/filters.texi
@@ -26736,6 +26736,17 @@ See @ref{framesync}.
 @item repeatlast
 See @ref{framesync}.
 
+@item blend_method
+Specify blend method if the second input has alpha channel. It accepts
+one of the following values:
+
+@table @option
+@item straight
+Straight alpha (the default).
+@item premultiplied
+Premultiplied alpha if supported, otherwise fallback to the default method.
+@end table
+
 @end table
 
 This filter also supports the @ref{framesync} options.


### PR DESCRIPTION
VAAPI driver might not advertise premultiplied alpha in the caps, so we should check whether premultiplied alpha is supported before setting blend flags with VA_BLEND_PREMULTIPLIED_ALPHA.

In addition, add blend_method option to allow user to specify blend method when the second input has alpha channel.