### PR TITLE
lavfi/tonemap_vaapi: remove HDR metadata

### DIFF
--- a/libavfilter/vf_tonemap_vaapi.c
+++ b/libavfilter/vf_tonemap_vaapi.c
@@ -309,6 +309,9 @@ static int tonemap_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame
            av_get_pix_fmt_name(output_frame->format),
            output_frame->width, output_frame->height, output_frame->pts);
 
+    av_frame_remove_side_data(output_frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+    av_frame_remove_side_data(output_frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+
     return ff_filter_frame(outlink, output_frame);
 
 fail:


### PR DESCRIPTION
The HDR metadata should be removed after HDR to SDR conversion, otherwise the output frame still has HDR side data.