### PR TITLE
lavc/qsvenc_hevc: restore the default gop size

### DIFF
--- a/libavcodec/qsvenc_hevc.c
+++ b/libavcodec/qsvenc_hevc.c
@@ -376,7 +376,7 @@ static const AVClass class = {
 static const FFCodecDefault qsv_enc_defaults[] = {
     { "b",         "1M"    },
     { "refs",      "0"     },
-    { "g",         "-1"    },
+    { "g",         "248"   },
     { "bf",        "-1"    },
     { "qmin",      "-1"    },
     { "qmax",      "-1"    },


### PR DESCRIPTION
commit a3c0a3e changed the default settings and expected the runtime can choose a best value. However the runtime doesn't set a valid gop size for hevc encoder, hence the output steam is non-seekable, which is inconvenient to user [1][2]

[1] https://github.com/intel/media-driver/issues/1576
[2] https://ffmpeg.org/pipermail/ffmpeg-user/2023-August/056716.html