### PR TITLE
libavfilter/vf_vpp_qsv: Fix a timestamp bug when framerate is not set

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -536,7 +536,10 @@ static int config_output(AVFilterLink *outlink)
     outlink->w          = vpp->out_width;
     outlink->h          = vpp->out_height;
     outlink->frame_rate = vpp->framerate;
-    outlink->time_base  = av_inv_q(vpp->framerate);
+    if (vpp->framerate.num == 0 || vpp->framerate.den == 0)
+        outlink->time_base = inlink->time_base;
+    else
+        outlink->time_base = av_inv_q(vpp->framerate);
 
     param.filter_frame  = NULL;
     param.set_frame_ext_params = vpp_set_frame_ext_params;


### PR DESCRIPTION
If user doesn't set framerate when he creates a filter, the filter uses default framerate {0, 1}. This causes error when setting timebase to 1/framerate. Now change it to pass inlink->time_base to outlink when framerate is not set.
This patch fixes ticket: #10476 #10468