### PR TITLE
configure: don't warn deprecated symbols from libvpl

### DIFF
--- a/configure
+++ b/configure
@@ -6776,6 +6776,7 @@ elif enabled libvpl; then
 # is extracted from "vpl >= 2.6"
     check_pkg_config libmfx "vpl >= 2.6" "mfxvideo.h mfxdispatcher.h" MFXLoad || \
             die "ERROR: libvpl >= 2.6 not found"
+    add_cflags -DMFX_DEPRECATED_OFF
 fi
 
 if enabled libmfx; then


### PR DESCRIPTION
Some symbols are deprecated in libvpl (e.g. MFX_EXTBUFF_VPP_DENOISE2 is used to replace MFX_EXTBUFF_VPP_DENOISE, but MFX_EXTBUFF_VPP_DENOISE2 is not supported in MediaSDK runtime). In order to support MediaSDK runtime, we have to use these deprecated symbols, so add -DMFX_DEPRECATED_OFF to CFLAGS to silence the corresponding compilation warnings