### PR TITLE
lavu/hwcontext_vaapi: ignore nonexistent device in default DRM device selection

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -1733,8 +1733,18 @@ static int vaapi_device_create(AVHWDeviceContext *ctx, const char *device,
                          "/dev/dri/renderD%d", 128 + n);
                 priv->drm_fd = open(path, O_RDWR);
                 if (priv->drm_fd < 0) {
-                    av_log(ctx, AV_LOG_VERBOSE, "Cannot open "
-                           "DRM render node for device %d.\n", n);
+                    if (errno == ENOENT) {
+                        if (n != max_devices - 1) {
+                            av_log(ctx, AV_LOG_VERBOSE,
+                                   "No render device %s, try next device for "
+                                   "DRM render node.\n", path);
+                            continue;
+                        } else
+                            av_log(ctx, AV_LOG_VERBOSE, "No avaialbe render device "
+                                   "for DRM render node.\n");
+                    } else
+                        av_log(ctx, AV_LOG_VERBOSE, "Cannot open "
+                               "DRM render node for device %d.\n", n);
                     break;
                 }
 #if CONFIG_LIBDRM


### PR DESCRIPTION
It is possible that renderD128 doesn't exist but renderD129 is available in a system (e.g. a docker host has multiple devices, but only renderD129 is mapped to a docker container). This change can make sure the default DRM device selection works even if renderD128 doesn't exist.