### PR TITLE
hwcontext_opencl: choose the first device if multiple devices are available

### DIFF
--- a/doc/ffmpeg.texi
+++ b/doc/ffmpeg.texi
@@ -1424,6 +1424,8 @@ Choose the GPU subdevice with type @samp{dxva2} and create QSV device with @samp
 The set of devices can also be filtered using the key-value pairs to find only
 devices matching particular platform or device strings.
 
+If more than one matching device found, choose the first one from the set of devices.
+
 The strings usable as filters are:
 @table @option
 @item platform_profile
@@ -1444,6 +1446,9 @@ The indices and filters must together uniquely select a device.
 
 Examples:
 @table @emph
+@item -init_hw_device opencl
+Choose the first device on the first platform.
+
 @item -init_hw_device opencl:0.1
 Choose the second device on the first platform.
 

--- a/libavutil/hwcontext_opencl.c
+++ b/libavutil/hwcontext_opencl.c
@@ -515,7 +515,7 @@ static int opencl_device_create_internal(AVHWDeviceContext *hwdev,
         return err;
 
     found = 0;
-    for (p = 0; p < nb_platforms; p++) {
+    for (p = nb_platforms - 1; p >= 0; p--) {
         const char *platform_name;
 
         if (selector->platform_index >= 0 &&
@@ -546,7 +546,7 @@ static int opencl_device_create_internal(AVHWDeviceContext *hwdev,
         if (err < 0)
             continue;
 
-        for (d = 0; d < nb_devices; d++) {
+        for (d = nb_devices - 1; d >= 0; d--) {
             const char *device_name;
 
             if (selector->device_index >= 0 &&
@@ -588,9 +588,8 @@ static int opencl_device_create_internal(AVHWDeviceContext *hwdev,
         goto fail;
     }
     if (found > 1) {
-        av_log(hwdev, AV_LOG_ERROR, "More than one matching device found.\n");
-        err = AVERROR(ENODEV);
-        goto fail;
+        av_log(hwdev, AV_LOG_VERBOSE,
+               "More than one matching device found, choose the first device.\n");
     }
 
     if (!props) {


### PR DESCRIPTION
This makes '-init_hw_device opencl' work in a multiple-device system.