### PR TITLE
lavu/vulkan_filter: fix input format

### DIFF
--- a/libavfilter/vulkan_filter.c
+++ b/libavfilter/vulkan_filter.c
@@ -187,6 +187,7 @@ int ff_vk_filter_config_input(AVFilterLink *inlink)
     s->input_frames_ref = inlink->hw_frames_ctx;
 
     /* Defaults */
+    s->input_format = input_frames->sw_format;
     s->output_format = input_frames->sw_format;
     s->output_width = inlink->w;
     s->output_height = inlink->h;


### PR DESCRIPTION
Otherwise s->input_format is always yuv420p, which will result in wrong output format in vulkan filters.

This fixes invalid output format for hwframe download in the command below:
./ffmpeg -init_hw_device vulkan -f lavfi \
	-i testsrc=duration=1,format=nv12 \
	-vf 'hwupload,format=vulkan,scale_vulkan=1024:768,hwdownload,format=nv12' \
	-f null -