### PR TITLE
libavcodec/qsvdec: add dump_extra bsf to h264/hevc_qsv decoder

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -1160,7 +1160,7 @@ static const AVOption hevc_options[] = {
         { "off",     NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_GPUCOPY_OFF },     0, 0, VD, .unit = "gpu_copy"},
     { NULL },
 };
-DEFINE_QSV_DECODER_WITH_OPTION(hevc, HEVC, "hevc_mp4toannexb", hevc_options)
+DEFINE_QSV_DECODER_WITH_OPTION(hevc, HEVC, "hevc_mp4toannexb,dump_extra", hevc_options)
 #endif
 
 static const AVOption options[] = {
@@ -1174,7 +1174,7 @@ static const AVOption options[] = {
 };
 
 #if CONFIG_H264_QSV_DECODER
-DEFINE_QSV_DECODER(h264, H264, "h264_mp4toannexb")
+DEFINE_QSV_DECODER(h264, H264, "h264_mp4toannexb,dump_extra")
 #endif
 
 #if CONFIG_MPEG2_QSV_DECODER


### PR DESCRIPTION
According to VPL doc:

"Before decoding the first frame, a sequence header must be present. The function skips any bitstreams before it encounters the new sequence header."

When decode a live video, sequence header is passed through sdp and video stream may not have sequence header. In this case qsv_decoder cannot decode header and keep waiting for more data.

For example:
push stream:
ffmpeg -v verbose -re -stream_loop -1 -i input.mp4 -c:v hevc_qsv \
 -bsf:v extract_extradata=remove=1 -f rtsp \
 rtsp://localhost:8554/mystream

receive stream:
ffmpeg -v verbose -hwaccel qsv -i rtsp://localhost:8554/mystream \
 -f null -

Header data is stored in extradata, so add "dump_extra" bsf into qsvdec, and then qsv decoder works on video stream without sequence header.