### PR TITLE
lavc/vaapi_hevc: Add support for Main Intra & Main 10 Intra

### DIFF
--- a/libavcodec/vaapi_hevc.c
+++ b/libavcodec/vaapi_hevc.c
@@ -612,6 +612,13 @@ VAProfile ff_vaapi_parse_hevc_rext_scc_profile(AVCodecContext *avctx)
         av_log(avctx, AV_LOG_VERBOSE, "HEVC profile %s is found.\n", profile->name);
     }
 
+#if VA_CHECK_VERSION(0, 37, 0)
+    if (!strcmp(profile->name, "Main Intra"))
+        return VAProfileHEVCMain;
+    else if (!strcmp(profile->name, "Main 10 Intra"))
+        return VAProfileHEVCMain10;
+#endif
+
 #if VA_CHECK_VERSION(1, 2, 0)
     if (!strcmp(profile->name, "Main 12") ||
         !strcmp(profile->name, "Main 12 Intra"))


### PR DESCRIPTION
Both Main Intra and Main 10 Intra are Rext. This patch fixes the error below:

[hevc @ 0x55a771b80a00] No support for codec hevc profile 4. 
[hevc @ 0x55a771b80a00] Failed setup for format vaapi: hwaccel initialisation returned error.