### PR TITLE
avcodec/hevc_ps: fix a potential memcmp mismatch

### DIFF
--- a/libavcodec/hevc_ps.h
+++ b/libavcodec/hevc_ps.h
@@ -153,7 +153,6 @@ typedef struct PTL {
 
 typedef struct HEVCVPS {
     unsigned int vps_id;
-    HEVCHdrParams *hdr;
 
     uint8_t vps_temporal_id_nesting_flag;
     int vps_max_layers;
@@ -175,6 +174,7 @@ typedef struct HEVCVPS {
 
     uint8_t data[4096];
     int data_size;
+    HEVCHdrParams *hdr;
 } HEVCVPS;
 
 typedef struct ScalingList {


### PR DESCRIPTION
HEVCHdrParams* receives a pointer which points to a dynamically allocated memory block. It causes the memcmp always returning 1. Add a function to do the comparision. A condition is also added to avoid malloc(0).