### PR TITLE
lavfi/dnn_backend_torch: Include mem.h

### DIFF
--- a/libavfilter/dnn/dnn_backend_torch.cpp
+++ b/libavfilter/dnn/dnn_backend_torch.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "dnn_io_proc.h"
 #include "dnn_backend_common.h"
 #include "libavutil/opt.h"
+#include "libavutil/mem.h"
 #include "queue.h"
 #include "safe_queue.h"
 }


### PR DESCRIPTION
Fix build fail since 790f793844.