### PR TITLE
lavc/vp9: Fix regression introduced in 0ba05857

### DIFF
--- a/libavcodec/vp9.c
+++ b/libavcodec/vp9.c
@@ -1735,9 +1735,9 @@ static int vp9_decode_frame(AVCodecContext *avctx, AVFrame *frame,
         if (ret < 0)
             goto fail;
     }
-    ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
 
 finish:
+    ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
     // ref frame setup
     for (int i = 0; i < 8; i++)
         ff_progress_frame_replace(&s->s.refs[i], &s->next_refs[i]);


### PR DESCRIPTION
ff_progress_frame_await() is called when hardware acceleration method is used, however ff_progress_frame_report() isn't called. A decoding thread for VP9 might get stuck.