### PR TITLE
lavc/qsvdec: Allow decoders to export crop information

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -856,6 +856,10 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
             else
                 frame->flags &= ~AV_FRAME_FLAG_KEY;
         }
+        frame->crop_left   = outsurf->Info.CropX;
+        frame->crop_top    = outsurf->Info.CropY;
+        frame->crop_right  = outsurf->Info.Width - (outsurf->Info.CropX + outsurf->Info.CropW);
+        frame->crop_bottom = outsurf->Info.Height - (outsurf->Info.CropY + outsurf->Info.CropH);
 
         /* update the surface properties */
         if (avctx->pix_fmt == AV_PIX_FMT_QSV)
@@ -1145,7 +1149,7 @@ const FFCodec ff_##x##_qsv_decoder = { \
     .p.priv_class   = &x##_qsv_class, \
     .hw_configs     = qsv_hw_configs, \
     .p.wrapper_name = "qsv", \
-    .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE, \
+    .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | FF_CODEC_CAP_EXPORTS_CROPPING, \
 }; \
 
 #define DEFINE_QSV_DECODER(x, X, bsf_name) DEFINE_QSV_DECODER_WITH_OPTION(x, X, bsf_name, options)

--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -133,26 +133,26 @@ static int qsv_get_continuous_buffer(AVCodecContext *avctx, AVFrame *frame,
     if (ret < 0)
         return ret;
 
-    frame->width       = avctx->width;
-    frame->height      = avctx->height;
+    frame->width       = avctx->coded_width;
+    frame->height      = avctx->coded_height;
 
     switch (avctx->pix_fmt) {
     case AV_PIX_FMT_NV12:
-        frame->linesize[0] = FFALIGN(avctx->width, 128);
+        frame->linesize[0] = FFALIGN(avctx->coded_width, 128);
         break;
     case AV_PIX_FMT_P010:
     case AV_PIX_FMT_P012:
     case AV_PIX_FMT_YUYV422:
-        frame->linesize[0] = 2 * FFALIGN(avctx->width, 128);
+        frame->linesize[0] = 2 * FFALIGN(avctx->coded_width, 128);
         break;
     case AV_PIX_FMT_Y210:
     case AV_PIX_FMT_VUYX:
     case AV_PIX_FMT_XV30:
     case AV_PIX_FMT_Y212:
-        frame->linesize[0] = 4 * FFALIGN(avctx->width, 128);
+        frame->linesize[0] = 4 * FFALIGN(avctx->coded_width, 128);
         break;
     case AV_PIX_FMT_XV36:
-        frame->linesize[0] = 8 * FFALIGN(avctx->width, 128);
+        frame->linesize[0] = 8 * FFALIGN(avctx->coded_width, 128);
         break;
     default:
         av_log(avctx, AV_LOG_ERROR, "Unsupported pixel format.\n");
@@ -169,7 +169,7 @@ static int qsv_get_continuous_buffer(AVCodecContext *avctx, AVFrame *frame,
         avctx->pix_fmt == AV_PIX_FMT_P012) {
         frame->linesize[1] = frame->linesize[0];
         frame->data[1] = frame->data[0] +
-            frame->linesize[0] * FFALIGN(avctx->height, 64);
+            frame->linesize[0] * FFALIGN(avctx->coded_height, 64);
     }
 
     ret = ff_attach_decode_data(frame);
@@ -381,7 +381,7 @@ static int qsv_decode_init_context(AVCodecContext *avctx, QSVContext *q, mfxVide
 
     if (!avctx->hw_frames_ctx)
         q->pool = av_buffer_pool_init(av_image_get_buffer_size(avctx->pix_fmt,
-                    FFALIGN(avctx->width, 128), FFALIGN(avctx->height, 64), 1), av_buffer_allocz);
+                    FFALIGN(avctx->coded_width, 128), FFALIGN(avctx->coded_height, 64), 1), av_buffer_allocz);
     return 0;
 }
 


### PR DESCRIPTION
Correct frame resolution when it change inside a sequence which has max width/height in its syntax. In this case, it will not trigger reinit process, and use the 1st frame's resolution for all frames.