### PR TITLE
lavc/qsvdec: fix keyframes

### DIFF
--- a/libavcodec/qsvdec.c
+++ b/libavcodec/qsvdec.c
@@ -885,9 +885,15 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
         frame->flags |= AV_FRAME_FLAG_INTERLACED *
             !(outsurf->Info.PicStruct & MFX_PICSTRUCT_PROGRESSIVE);
         frame->pict_type = ff_qsv_map_pictype(aframe.frame->dec_info.FrameType);
-        //Key frame is IDR frame is only suitable for H264. For HEVC, IRAPs are key frames.
-        if (avctx->codec_id == AV_CODEC_ID_H264) {
+
+        if (avctx->codec_id == AV_CODEC_ID_H264 ||
+            avctx->codec_id == AV_CODEC_ID_HEVC) {
             if (aframe.frame->dec_info.FrameType & MFX_FRAMETYPE_IDR)
+                frame->flags |= AV_FRAME_FLAG_KEY;
+            else
+                frame->flags &= ~AV_FRAME_FLAG_KEY;
+        } else {
+            if (aframe.frame->dec_info.FrameType & MFX_FRAMETYPE_I)
                 frame->flags |= AV_FRAME_FLAG_KEY;
             else
                 frame->flags &= ~AV_FRAME_FLAG_KEY;

--- a/libavcodec/qsvenc.c
+++ b/libavcodec/qsvenc.c
@@ -2482,7 +2482,7 @@ static int encode_frame(AVCodecContext *avctx, QSVEncContext *q,
 
         if (frame->pict_type == AV_PICTURE_TYPE_I) {
             enc_ctrl->FrameType = MFX_FRAMETYPE_I | MFX_FRAMETYPE_REF;
-            if (q->forced_idr)
+            if ((frame->flags & AV_FRAME_FLAG_KEY) || q->forced_idr)
                 enc_ctrl->FrameType |= MFX_FRAMETYPE_IDR;
         }
     }


### PR DESCRIPTION
The SDK set frame type to MFX_FRAMETYPE_IDR for keyframes in H.264, HEVC and MPEG-2, set frame type to MFX_FRAMETYPE_I for keyframes in other codecs, hence we may mark the output frame as keyframe accordingly.