### PR TITLE
lavf/vpp_qsv: Add input hw resolution alignment check for passthrough

### DIFF
--- a/libavfilter/vf_vpp_qsv.c
+++ b/libavfilter/vf_vpp_qsv.c
@@ -524,7 +524,7 @@ static int vpp_set_frame_ext_params(AVFilterContext *ctx, const AVFrame *in, AVF
 
 static int config_output(AVFilterLink *outlink)
 {
-    FilterLink     *outl = ff_filter_link(outlink);
+    FilterLink      *outl = ff_filter_link(outlink);
     AVFilterContext *ctx = outlink->src;
     VPPContext      *vpp = ctx->priv;
     QSVVPPParam     param = { NULL };
@@ -532,13 +532,12 @@ static int config_output(AVFilterLink *outlink)
     mfxExtBuffer    *ext_buf[ENH_FILTERS_COUNT];
     mfxVersion      mfx_version;
     AVFilterLink    *inlink = ctx->inputs[0];
-    FilterLink         *inl = ff_filter_link(inlink);
-    FilterLink          *ol = ff_filter_link(outlink);
+    FilterLink      *inl = ff_filter_link(inlink);
     enum AVPixelFormat in_format;
 
     outlink->w          = vpp->out_width;
     outlink->h          = vpp->out_height;
-    ol->frame_rate      = vpp->framerate;
+    outl->frame_rate    = vpp->framerate;
     if (vpp->framerate.num == 0 || vpp->framerate.den == 0)
         outlink->time_base = inlink->time_base;
     else


### PR DESCRIPTION
Align vpp output hw frame resolution with 32 that can be more compatible with downstream QSV encoders which requires 32 alignment for some case.