### PR TITLE
libavutil/hwcontext_d3d11va: Support Y212/XV36 pixel format

### DIFF
--- a/libavutil/hwcontext_d3d11va.c
+++ b/libavutil/hwcontext_d3d11va.c
@@ -104,6 +104,10 @@ static const struct {
     { DXGI_FORMAT_P016,         AV_PIX_FMT_P012 },
     { DXGI_FORMAT_Y216,         AV_PIX_FMT_Y216 },
     { DXGI_FORMAT_Y416,         AV_PIX_FMT_XV48 },
+    // There is no 12bit pixel format defined in DXGI_FORMAT*, use 16bit to compatible
+    // with 12 bit AV_PIX_FMT* formats.
+    { DXGI_FORMAT_Y216,         AV_PIX_FMT_Y212 },
+    { DXGI_FORMAT_Y416,         AV_PIX_FMT_XV36 },
     // Special opaque formats. The pix_fmt is merely a place holder, as the
     // opaque format cannot be accessed directly.
     { DXGI_FORMAT_420_OPAQUE,   AV_PIX_FMT_YUV420P },

--- a/libavutil/hwcontext_dxva2.c
+++ b/libavutil/hwcontext_dxva2.c
@@ -95,6 +95,10 @@ static const struct {
     { MKTAG('P', '0', '1', '6'), AV_PIX_FMT_P012 },
     { MKTAG('Y', '2', '1', '6'), AV_PIX_FMT_Y216 },
     { MKTAG('Y', '4', '1', '6'), AV_PIX_FMT_XV48 },
+    // There is no 12bit pixel format defined in D3DFMT*, use 16bit to compatible
+    // with 12 bit AV_PIX_FMT* formats.
+    { MKTAG('Y', '2', '1', '6'), AV_PIX_FMT_Y212 },
+    { MKTAG('Y', '4', '1', '6'), AV_PIX_FMT_XV36 },
     { D3DFMT_P8,                 AV_PIX_FMT_PAL8 },
     { D3DFMT_A8R8G8B8,           AV_PIX_FMT_BGRA },
 };


### PR DESCRIPTION
Use DXGI 16bit pixel format to compatible with 12bit Y212/XV36 since there is no 12bit pixel defined in D3D11.

Fix cmdline on Windows:

$ ffmpeg.exe -hwaccel qsv -i input_12bit.bin -f null -