### PR TITLE
lavfi/qsvvpp: Copy frame props before modify it

### DIFF
--- a/libavfilter/qsvvpp.c
+++ b/libavfilter/qsvvpp.c
@@ -471,7 +471,8 @@ static QSVFrame *submit_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *p
 }
 
 /* get the output surface */
-static QSVFrame *query_frame(QSVVPPContext *s, AVFilterLink *outlink, const AVFrame *in)
+static QSVFrame *query_frame(QSVVPPContext *s, AVFilterLink *outlink, const AVFrame *in,
+                             const AVFrame *propref)
 {
     FilterLink *l = ff_filter_link(outlink);
     AVFilterContext *ctx = outlink->src;
@@ -511,6 +512,15 @@ static QSVFrame *query_frame(QSVVPPContext *s, AVFilterLink *outlink, const AVFr
                                    &out_frame->surface);
         if (ret < 0)
             return NULL;
+    }
+
+    if (propref) {
+        ret = av_frame_copy_props(out_frame->frame, propref);
+        if (ret < 0) {
+            av_frame_free(&out_frame->frame);
+            av_log(ctx, AV_LOG_ERROR, "Failed to copy metadata fields from src to dst.\n");
+            return NULL;
+        }
     }
 
     if (l->frame_rate.num && l->frame_rate.den)
@@ -985,7 +995,7 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
     }
 
     do {
-        out_frame = query_frame(s, outlink, in_frame->frame);
+        out_frame = query_frame(s, outlink, in_frame->frame, propref);
         if (!out_frame) {
             av_log(ctx, AV_LOG_ERROR, "Failed to query an output frame.\n");
             return AVERROR(ENOMEM);
@@ -1007,15 +1017,6 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
             if (ret == MFX_ERR_MORE_DATA)
                 return AVERROR(EAGAIN);
             break;
-        }
-
-        if (propref) {
-            ret1 = av_frame_copy_props(out_frame->frame, propref);
-            if (ret1 < 0) {
-                av_frame_free(&out_frame->frame);
-                av_log(ctx, AV_LOG_ERROR, "Failed to copy metadata fields from src to dst.\n");
-                return ret1;
-            }
         }
 
         out_frame->frame->pts = av_rescale_q(out_frame->surface.Data.TimeStamp,


### PR DESCRIPTION
The changes to output frame props in query_frame overlapped since b14ed6ea58. Move the copy frame props before the changes.