### PR TITLE
ffmpeg_tools/filter: duration needs to be aligned with time_base.

### DIFF
--- a/fftools/ffmpeg_filter.c
+++ b/fftools/ffmpeg_filter.c
@@ -2532,6 +2532,9 @@ static int fg_output_step(OutputFilterPriv *ofp, FilterGraphThread *fgt,
         return 0;
     }
 
+    // Frame's duration needs to be aligned with its time_base.
+    if(frame->duration)
+        frame->duration = av_rescale_q(frame->duration, frame->time_base, av_buffersink_get_time_base(filter));
     frame->time_base = av_buffersink_get_time_base(filter);
 
     if (debug_ts)


### PR DESCRIPTION
catch a timestamp issue when vpp send to encode.
test case: `ffmpeg -v verbose -hwaccel qsv -init_hw_device qsv=qsv,child_device=/dev/dri/renderD128 -hwaccel_output_format qsv -c:v hevc_qsv -i intput.hevc -vf "vpp_qsv=w=720:h=480" -c:v hevc_qsv -y output.hevc`
log:
```
[Parsed_vpp_qsv_0 @ 0x7178f8002bc0] VPP: input is video memory surface
[Parsed_vpp_qsv_0 @ 0x7178f8002bc0] VPP: output is video memory surface
[graph -1 input from stream 0:0 @ 0x7178f8003340] video frame properties congruent with link at pts_time: 0
[vf#0:0 @ 0x60d2436b7ec0] *** 23999 dup!
[vost#0:0/hevc_qsv @ 0x60d243644540] [enc:hevc_qsv @ 0x60d243780000] Using input frames context (format qsv) with hevc_qsv encoder.
[hevc_qsv @ 0x60d2435ed980] Encoder: input is video memory surface
[hevc_qsv @ 0x60d2435ed980] Use Intel(R) oneVPL to create MFX session with the specified MFX loader
```
intput.hevc : 
 Stream #0:0: Video: hevc (Rext), yuv422p(tv), 1920x1080, 25 fps, 50 tbr, 1200k tbn ,**frame=  500**
output.hevc:
 Stream #0:0: Video: hevc (Rext), yuv422p(tv), 720x480 [SAR 1:1 DAR 3:2], 25 fps, 50 tbr, 1200k tbn, **frame=24499**

after the fixed patch,the new output.hevc:
Stream #0:0: Video: hevc (Rext), yuv422p(tv), 720x480 [SAR 1:1 DAR 3:2], 25 fps, 50 tbr, 1200k tbn, **frame=  500**
