### PR TITLE
Modify ffmpeg alloc to 4kB alignment if QSV is enabled and >1MB buffe…

### DIFF
--- a/libavutil/mem.c
+++ b/libavutil/mem.c
@@ -98,21 +98,26 @@ static int size_mult(size_t a, size_t b, size_t *r)
 void *av_malloc(size_t size)
 {
     void *ptr = NULL;
+    size_t alignment = ALIGN;
 
     if (size > atomic_load_explicit(&max_alloc_size, memory_order_relaxed))
         return NULL;
 
+#if CONFIG_QSV
+    if ((size > 1024*1024) && (alignment < 4096))
+        alignment = 4096;
+#endif
 #if HAVE_POSIX_MEMALIGN
     if (size) //OS X on SDK 10.6 has a broken posix_memalign implementation
-    if (posix_memalign(&ptr, ALIGN, size))
+    if (posix_memalign(&ptr, alignment, size))
         ptr = NULL;
 #elif HAVE_ALIGNED_MALLOC
-    ptr = _aligned_malloc(size, ALIGN);
+    ptr = _aligned_malloc(size, alignment);
 #elif HAVE_MEMALIGN
 #ifndef __DJGPP__
-    ptr = memalign(ALIGN, size);
+    ptr = memalign(alignment, size);
 #else
-    ptr = memalign(size, ALIGN);
+    ptr = memalign(size, alignment);
 #endif
     /* Why 64?
      * Indeed, we should align it:


### PR DESCRIPTION
…r is allocated; required for HW-enabled copy in GPU.

This give even up to 18% better performance 
In case of running e.g. such command:
ffmpeg \
      -qsv_device /dev/dri/renderD128 -hwaccel qsv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -pix_fmt yuv422p10le -video_size 1920x1080 -i /videos/1920x1080p10le_1.yuv \
      -filter_complex "[0:v]hwupload,scale_qsv=iw/4:ih/4[out0]; \
                       [1:v]hwupload,scale_qsv=iw/4:ih/4[out1]; \
                       [2:v]hwupload,scale_qsv=iw/4:ih/4[out2]; \
                       [3:v]hwupload,scale_qsv=iw/4:ih/4[out3]; \
                       [4:v]hwupload,scale_qsv=iw/4:ih/4[out4]; \
                       [5:v]hwupload,scale_qsv=iw/4:ih/4[out5]; \
                       [6:v]hwupload,scale_qsv=iw/4:ih/4[out6]; \
                       [7:v]hwupload,scale_qsv=iw/4:ih/4[out7]; \
                       [8:v]hwupload,scale_qsv=iw/4:ih/4[out8]; \
                       [9:v]hwupload,scale_qsv=iw/4:ih/4[out9]; \
                       [10:v]hwupload,scale_qsv=iw/4:ih/4[out10]; \
                       [11:v]hwupload,scale_qsv=iw/4:ih/4[out11]; \
                       [12:v]hwupload,scale_qsv=iw/4:ih/4[out12]; \
                       [13:v]hwupload,scale_qsv=iw/4:ih/4[out13]; \
                       [14:v]hwupload,scale_qsv=iw/4:ih/4[out14]; \
                       [15:v]hwupload,scale_qsv=iw/4:ih/4[out15]; \
                       [out0][out1][out2][out3] \
                       [out4][out5][out6][out7] \
                       [out8][out9][out10][out11] \
                       [out12][out13][out14][out15] \
                       xstack_qsv=inputs=16:\
layout=xstack=inputs=16:layout=0_0|0_h0|0_h0+h1|0_h0+h1+h2|w0_0|w0_h0|w0_h0+h1|w0_h0+h1+h2|w0+w4_0|w0+w4_h0|w0+w4_h0+h1|w0+w4_h0+h1+h2|w0+w4+w8_0|w0+w4+w8_h0|w0+w4+w8_h0+h1|w0+w4+w8_h0+h1+h2,\
                       format=y210le,format=yuv422p10le" \
      /videos/recv_1920x1080p10le.yuv
