### PR TITLE
Encoding av1 4k 10 bit videos have effect of added green tint to output video.

### DIFF
--- a/libavcodec/vaapi_encode_av1.c
+++ b/libavcodec/vaapi_encode_av1.c
@@ -446,6 +446,7 @@ static int vaapi_encode_av1_init_sequence_params(AVCodecContext *avctx)
     vseq->ip_period               = base_ctx->b_per_p + 1;
 
     vseq->seq_fields.bits.enable_order_hint = sh->enable_order_hint;
+    vseq->seq_fields.bits.bit_depth_minus8 = desc->comp[0].depth - 8;
 
     if (!(ctx->va_rc_mode & VA_RC_CQP)) {
         vseq->bits_per_second = ctx->va_bit_rate;


### PR DESCRIPTION
Media Transcode Accelerator team noticed problem during encoding of 10bit yuv files (P010 format) with AV1 encoder.

JIRA report:
[VCX-967] [BM][AUX] Green tint on av1 4K 10 bit videos - https://jira.devtools.intel.com/browse/VCX-967

Test commands:
ffmpeg -hwaccel vaapi -init_hw_device vaapi=hw:/dev/dri/renderD128 -hwaccel_output_format vaapi -v verbose -f rawvideo -pix_fmt p010le  -s:v 3840x2160 -r:v 30 -i /home/media_asset/yuv/4K_3840x2160_100frames.P010 -vf format=p010le,hwupload -an -c:v av1_vaapi -rc_mode CBR -g 100 -slices 1 -bf 3 -b:v 30000k -maxrate 30000k -vframes 30 -y logs/latest/tests/functional/av1/test_ffmpeg_encode.py::test_10bit[ffmpeg_vaapi_av1_encode_10bit_5].result.ivf

ffmpeg -hwaccel vaapi -init_hw_device vaapi=hw:/dev/dri/renderD128 -hwaccel_output_format vaapi -v verbose -f rawvideo -pix_fmt p010le  -s:v 3840x2160 -r:v 30 -i /home/media_asset/yuv/4K_3840x2160_100frames.P010 -vf format=p010le,hwupload -an -c:v av1_vaapi -rc_mode CBR -g 100 -slices 2 -bf 3 -b:v 30000k -maxrate 30000k -vframes 30 -y logs/latest/tests/functional/av1/test_ffmpeg_encode.py::test_10bit[ffmpeg_vaapi_av1_encode_10bit_6].result.ivf

Result image:
![image](https://github.com/user-attachments/assets/1013a38c-f46d-4533-896c-7c0e2f8d4960)

We also created a patch for ffmpeg a few months ago (Dec 20, 2024) but without any reaction from community: https://patchwork.ffmpeg.org/project/ffmpeg/patch/20241220122334.246434-1-grzegorz.rys@intel.com/
