### PR TITLE
Fix memory sanitizer error in VA-API decode

### DIFF
--- a/libavcodec/vaapi_decode.c
+++ b/libavcodec/vaapi_decode.c
@@ -324,7 +324,7 @@ static int vaapi_decode_find_best_format(AVCodecContext *avctx,
     VASurfaceAttrib *attr;
     enum AVPixelFormat source_format, best_format, format;
     uint32_t best_fourcc, fourcc;
-    int i, j, nb_attr;
+    int i, j, nb_attr=0;
 
     source_format = avctx->sw_pix_fmt;
     av_assert0(source_format != AV_PIX_FMT_NONE);


### PR DESCRIPTION
When testing ffmpeg with VA-API I have encountered an error in using uninitialized variable.
According to VA-API documentation the last parameter of vaQuerySurfaceAttributes() is for reading and writing:
https://intel.github.io/libva/group__api__core.html#ga6b10b88a628c56377268714cc72090ce
