### PR TITLE
vaapi_encode_h264: enable deblocking filter control in PPS RTMP

### DIFF
--- a/libavcodec/vaapi_encode_h264.c
+++ b/libavcodec/vaapi_encode_h264.c
@@ -366,6 +366,8 @@ static int vaapi_encode_h264_init_sequence_params(AVCodecContext *avctx)
         .time_scale        = sps->vui.time_scale,
     };
 
+    pps->deblocking_filter_control_present_flag = 1;
+
     *vpic = (VAEncPictureParameterBufferH264) {
         .CurrPic = {
             .picture_id = VA_INVALID_ID,


### PR DESCRIPTION
Media Transcode Accelerator team noticed problem during streaming h264 it in real-time by nginx RTMP.

JIRA report:
[VCX-2012] [BM][AUX] Corruption on video when streaming it in realtime by nginx RTMP - [VCX-2012](https://jira.devtools.intel.com/browse/VCX-2012)

Test commands:
`ffmpeg -hwaccel vaapi \
         -re -init_hw_device vaapi=hw:/dev/dri/renderD128 \
         -hwaccel_output_format vaapi \
  -i /home/input \
         -muxdelay 0 -muxpreload 0 -reset_timestamps 1 \
         -compression_level 2 -profile:v high -c:v h264_vaapi -rc_mode CQP -qp 25 -vf scale_vaapi=w=3840:h=1714 -c:a aac -b:a 128k -f flv rtmp://localhost/live/2160p \
         -compression_level 2 -profile:v high -c:v h264_vaapi -rc_mode CQP -qp 25 -vf scale_vaapi=w=2560:h=1440 -c:a aac -b:a 128k -f flv rtmp://localhost/live/1440p \
         -compression_level 2 -profile:v high -c:v h264_vaapi -rc_mode CQP -qp 25 -vf scale_vaapi=w=1920:h=1080 -c:a aac -b:a 128k -f flv rtmp://localhost/live/1080p \
         -compression_level 2 -profile:v high -c:v h264_vaapi -rc_mode CQP -qp 25 -vf scale_vaapi=w=1280:h=720 -c:a aac -b:a 128k -f flv rtmp://localhost/live/720p \
         -compression_level 2 -profile:v high -c:v h264_vaapi -rc_mode CQP -qp 25 -vf scale_vaapi=w=640:h=480 -c:a aac -b:a 128k -f flv rtmp://localhost/live/480p`
         
Then you should be able to capture the video streams from the server
`ffmpeg -i [http://[YOUR_IP]:8080/hls/2160p.m3u8|http://[your_ip]/hls/2160p.m3u8] -c copy -t 60 output_gnrd.mp4
ffmpeg -i [http://[YOUR_IP]:8080|http://[your_ip]/]/hls/2160p_sw.m3u8 -c copy -t 60 output_sw.mp4`

Or you can use the VLC player to watch the video as it is served as HLS stream.

Result image
![image-2025-03-28-11-29-36-604](https://github.com/user-attachments/assets/3378b8d3-c183-4632-b959-12c8317a4568)
